### PR TITLE
Early exception handler

### DIFF
--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -2,4 +2,5 @@
 
 - [Introduction](./introduction.md)
 - [Kernel]()
+  - [Threads and Harts](./kernel/threads-and-harts.md)
 - [Targets]()

--- a/doc/kernel/threads-and-harts.md
+++ b/doc/kernel/threads-and-harts.md
@@ -1,0 +1,18 @@
+# Threads and Harts
+
+In ukoOS, there are three related concepts that are important to keep separate.
+
+- **harts**, or hardware threads.
+  Colloquially, we might call these "cores" or "CPUs."
+  This terminology comes from RISC-V, but the concept applies to any architecture.
+- **kthreads**, or kernel threads.
+  The kernel manages these automatically, and will create and destroy them at various times.
+- **uthreads**, or user threads.
+  These are the threads that userspace programmers talk about.
+  They are created only in response to userspace syscalls.
+
+Each of these notions of threads also has its own notion of "thread-locals."
+These are stored in various places.
+
+- Hart-locals are pointed to by the `sscratch` CSR, so we can get to them in trap handlers, regardless of whether the trap handler interrupted kernel-space or user-space execution.
+- Kernel and user thread-locals are pointed to by the `tp` register (`x4`).

--- a/src/kernel/arch/riscv64/hart_locals.c
+++ b/src/kernel/arch/riscv64/hart_locals.c
@@ -1,3 +1,4 @@
+#include <arch/riscv64/insns.h>
 #include <hart_locals.h>
 
 /**
@@ -20,15 +21,11 @@ static __attribute__((aligned(1 << MM_ALLOC_SEGMENT_SHIFT))) union {
 } boothart_heap_segment;
 
 struct hart_locals *get_hart_locals(void) {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuninitialized"
-  register struct hart_locals *tp __asm__("tp");
-  return tp;
-#pragma GCC diagnostic pop
+  return (struct hart_locals *)csrr(RISCV64_CSR_SSCRATCH);
 }
 
 void init_boothart_hart_locals(u64 hart_id) {
-  __asm__ volatile("la tp, %0\n" : : "i"(&boothart_hart_locals) :);
+  csrw(RISCV64_CSR_SSCRATCH, (u64)&boothart_hart_locals);
   boothart_hart_locals = (struct hart_locals){
       .hart_id = hart_id,
       .heap = &boothart_heap,

--- a/src/kernel/arch/riscv64/include.mak
+++ b/src/kernel/arch/riscv64/include.mak
@@ -1,4 +1,9 @@
-kernel-cflags += -fno-omit-frame-pointer -mabi=lp64 -march=rv64imac_zicsr_zicntr_zihpm_zba_zbb_zbs_zihintpause_zicbom_zicbop_zicboz -mcmodel=medany
+kernel-cflags += \
+	-DARCH_RISCV64 \
+	-fno-omit-frame-pointer \
+	-mabi=lp64 \
+	-march=rv64imac_zicsr_zicntr_zihpm_zba_zbb_zbs_zihintpause_zicbom_zicbop_zicboz \
+	-mcmodel=medany
 kernel-cflags += -Wconversion
 kernel-objs-asm += arch/riscv64/start
 kernel-objs-c += arch/riscv64/backtrace arch/riscv64/hart_locals arch/riscv64/paging arch/riscv64/panic arch/riscv64/sbi

--- a/src/kernel/arch/riscv64/start.S
+++ b/src/kernel/arch/riscv64/start.S
@@ -8,6 +8,105 @@
 .global _start
 .type _start, @function
 _start:
+	# Disable interrupts.
+	csrr t0, sstatus
+	and t0, t0, ~(1 << 1)
+	csrw sstatus, t0
+
+	# Set up the early-exception trap handler.
+	la t0, unrecoverable_exception
+	csrw stvec, t0
+
+	# Clear the return address and frame pointer.
 	mv ra, zero
-	mv s0, zero
+	mv fp, zero
+
+	# Call into main.
 	tail main
+
+.section .text
+
+/**
+ * A handler for an unrecoverable exception.
+ */
+.p2align 2
+.global unrecoverable_exception
+.type unrecoverable_exception, @function
+unrecoverable_exception:
+	mv s1, ra
+	la a0, unrecoverable_exception_msg0
+	call unrecoverable_exception_print_cstr
+	csrr a0, sepc
+	call unrecoverable_exception_print_hex
+	la a0, unrecoverable_exception_msg1
+	call unrecoverable_exception_print_cstr
+	mv a0, s1
+	call unrecoverable_exception_print_hex
+	la a0, unrecoverable_exception_msg2
+	call unrecoverable_exception_print_cstr
+	csrr a0, scause
+	call unrecoverable_exception_print_hex
+	la a0, unrecoverable_exception_msg3
+	call unrecoverable_exception_print_cstr
+	csrr a0, stval
+	call unrecoverable_exception_print_hex
+	la a0, unrecoverable_exception_msg4
+	call unrecoverable_exception_print_cstr
+	tail _panic_halt
+
+.type unrecoverable_exception_print_cstr, @function
+unrecoverable_exception_print_cstr:
+	mv t0, a0
+	li a6, 0
+	li a7, 1
+1:
+	lb a0, (t0)
+	beqz a0, 2f
+	ecall
+	addi t0, t0, 1
+	j 1b
+2:
+	ret
+
+.type unrecoverable_exception_print_hex, @function
+unrecoverable_exception_print_hex:
+	mv t0, a0
+	li t1, 16
+	la t2, unrecoverable_exception_digits
+	li a6, 0
+	li a7, 1
+1:
+	beqz t1, 2f
+	srli t3, t0, 60
+	slli t0, t0, 4
+	add t3, t2, t3
+	lb a0, (t3)
+	ecall
+	addi t1, t1, -1
+	j 1b
+2:
+	ret
+
+.section .rodata
+
+unrecoverable_exception_digits:
+	.ascii "0123456789abcdef"
+unrecoverable_exception_msg0:
+	.ascii "ukoOS: Got an unrecoverable exception!"
+	.byte 13, 10
+	.ascii "    PC: 0x"
+	.byte 0
+unrecoverable_exception_msg1:
+	.byte 13, 10
+	.ascii "    RA: 0x"
+	.byte 0
+unrecoverable_exception_msg2:
+	.byte 13, 10
+	.ascii "SCAUSE: 0x"
+	.byte 0
+unrecoverable_exception_msg3:
+	.byte 13, 10
+	.ascii " STVAL: 0x"
+	.byte 0
+unrecoverable_exception_msg4:
+	.byte 13, 10, 0


### PR DESCRIPTION
This is a lot less than what #9 proposes, so it doesn't close that. This just adds a basic exception handler, which looks like this:

<img width="1004" height="718" alt="image" src="https://github.com/user-attachments/assets/c6034c27-1a5f-4b81-b33e-27de44b82cc1" />

The handler from #9 / #5 should give a lot more information, but we won't be able to use it until after hart locals exist, since it'll need to store the register file into them.