### PR TITLE
Set Dev Container to use Host Network 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,6 +16,7 @@
                 "C_Cpp.clang_format_style": "LLVM"
             }
         }
-    }
+    },
+    "runArgs": ["--network=host"]
 }
 


### PR DESCRIPTION
This is needed because the tftp client needs to forward a random port to send files for some reason.