### PR TITLE
add gdb and ssh to dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,5 +13,7 @@ RUN apk add --no-interactive \
             minicom \
             perl \
             mdbook \
-            busybox-extras
+            busybox-extras \
+            gdb \
+            ssh
 


### PR DESCRIPTION
gdb is needed for debugging with `make gdb` and ssh is needed for git pulls when the ssh remote was cloned