### PR TITLE
Fix dependencies and make targets

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,5 +13,7 @@ RUN apk add --no-interactive \
             minicom \
             perl \
             mdbook \
-            busybox-extras
+            busybox-extras \
+            gdb \
+            ssh
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,6 +14,6 @@ RUN apk add --no-interactive \
             perl \
             mdbook \
             busybox-extras \
-            gdb \
-            ssh
+            gdb-multiarch \
+            openssh
 

--- a/src/kernel/arch/riscv64/include.mak
+++ b/src/kernel/arch/riscv64/include.mak
@@ -26,24 +26,22 @@ $(call defcleanable, \
 
 # Targets for booting and debugging the kernel.
 gdb: src/kernel/kernel.sym
-	gdb src/kernel/kernel.sym \
+	gdb-multiarch src/kernel/kernel.sym \
 		-ex "set substitute-path / $(srcdir)/" \
 		-ex "layout src" \
 		-ex "focus cmd" \
 		-ex "target remote :1234" \
 		-ex "break main" \
-		-ex "break _panic_halt" \
-		-ex "continue"
+		-ex "break _panic_halt"
 gdb_bootstub: src/kernel/kernel.sym
-	gdb src/kernel/kernel.sym \
+	gdb-multiarch src/kernel/kernel.sym \
 		-ex "set substitute-path / $(srcdir)/" \
 		-ex "layout asm" \
 		-ex "layout regs" \
 		-ex "focus cmd" \
 		-ex "target remote :1234" \
 		-ex "break *0x80080000" \
-		-ex "break main" \
-		-ex "continue"
+		-ex "break main"
 qemu: src/kernel/kernel.elf
 	qemu-system-riscv64 \
 		--machine virt \
@@ -53,7 +51,17 @@ qemu: src/kernel/kernel.elf
 		-nographic \
 		-kernel src/kernel/kernel.elf \
 		$(QEMUFLAGS)
-.PHONY: gdb gdb_bootstub qemu
+qemu-debug: src/kernel/kernel.elf
+	qemu-system-riscv64 \
+		--machine virt \
+		--cpu rva22s64 \
+		--smp 1 \
+		-m 1G \
+		-nographic \
+		-kernel src/kernel/kernel.elf \
+		-s -S \
+		$(QEMUFLAGS)
+.PHONY: gdb gdb_bootstub qemu qemu-debug
 
 # Link the kernel. This kernel will have debug symbols, and not actually be
 # bootable -- it depends on being loaded by and having the boot environment set


### PR DESCRIPTION
- ssh needed to be installed as openssh
- installing gdb alone doesn't seem to support risc-v, so install gdb-multiarch instead
- change make targets to use gdb-multiarch instead of plain gdb
- add qemu-debug target to replace manually running `make qemu QEMUFLAGS="-s -S"`


This is based off of the PR https://github.com/UMN-Kernel-Object/ukoos/pull/39 which added ssh and gdb to the dev container.

I could merge this into [june/add-missing-container-deps](https://github.com/UMN-Kernel-Object/ukoos/tree/june/add-missing-container-deps) but I kept it separate for simplicity, let me know if this should be done differently.