### PR TITLE
Adds a notion of targets.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,18 +2,17 @@ FROM docker.io/alpine:3.21
 RUN apk add --no-interactive \
             bash \
             binutils-riscv-none-elf \
+            busybox-extras \
             coreutils \
             gcc-riscv-none-elf \
+            gdb-multiarch \
             git \
             make \
+            mdbook \
+            minicom \
+            openssh \
+            perl \
             python3 \
             qemu-system-riscv64 \
             tar \
-            zstd \
-            minicom \
-            perl \
-            mdbook \
-            busybox-extras \
-            gdb-multiarch \
-            openssh
-
+            zstd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
           shortrev=$(git rev-parse --short HEAD)
           mkdir build
           cd build
-          ../configure
+          ../configure --target milkv-duos
           make -j$(nproc) -l$(nproc)
           mkdir ukoos-git-$shortrev
           make DESTDIR=$(realpath ukoos-git-$shortrev) install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,12 @@ jobs:
     runs-on: 'ubuntu-latest'
     container:
       image: docker.io/alpine:3.21
+    strategy:
+      matrix:
+        target:
+          - milkv-duos
+          - milkv-jupiter
+          - qemu-riscv64
     steps:
       - name: Install dependencies
         run: |
@@ -32,25 +38,26 @@ jobs:
           shortrev=$(git rev-parse --short HEAD)
           mkdir build
           cd build
-          ../configure --target milkv-duos
+          ../configure --target ${{ matrix.target }}
           make -j$(nproc) -l$(nproc)
-          mkdir ukoos-git-$shortrev
-          make DESTDIR=$(realpath ukoos-git-$shortrev) install
-          tar --create --file ukoos-git-$shortrev.tar \
+          name=ukoos-${{ matrix.target }}-git-$shortrev
+          mkdir $name
+          make DESTDIR=$(realpath $name) install
+          tar --create --file $name.tar \
             --format posix \
             --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
             --mtime "@$SOURCE_DATE_EPOCH" \
             --sort name \
             --owner 0 --group 0 --numeric-owner \
-            ukoos-git-$shortrev
-          zstd -19 --threads=0 ukoos-git-$shortrev.tar
-          sha256sum ukoos-git-$shortrev.tar ukoos-git-$shortrev.tar.zst
-          cp ukoos-git-$shortrev.tar.zst ../ukoos-git.tar.zst
+            $name
+          zstd -19 --threads=0 $name.tar
+          sha256sum $name.tar $name.tar.zst
+          cp $name.tar.zst ../ukoos-${{ matrix.target }}-git.tar.zst
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ukoos-git.tar.zst
-          path: ukoos-git.tar.zst
+          name: ukoos-${{ matrix.target }}-git.tar.zst
+          path: ukoos-${{ matrix.target }}-git.tar.zst
           compression-level: 0
   build-dev-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
             binutils-riscv-none-elf \
             coreutils \
             gcc-riscv-none-elf \
+            gdb-multiarch \
             git \
             make \
             mdbook \

--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,18 @@ endef
 include $(srcdir)/doc/include.mak
 include $(srcdir)/src/kernel/include.mak
 
+# Load the target.
+ifeq ($(realpath $(srcdir)/src/targets/$(arch)/$(target).mak),)
+$(error The target $(target) did not exist; rerun ./configure)
+endif
+include $(srcdir)/src/targets/$(arch)/$(target).mak
+
 # Common rules.
 all::
 $(call defcleanable,compile_commands.json)
 distclean: clean
-	@if [[ -e config.mak ]]; then echo "CLEAN config.mak"; rm config.mak; fi
+	@if [[ -e config.mak ]]; then echo "CLEAN   config.mak"; rm config.mak; fi
+	@if [[ -e Makefile ]]; then echo "CLEAN   Makefile"; rm Makefile; fi
 install::
 watch:
 	watchexec \

--- a/configure
+++ b/configure
@@ -160,6 +160,7 @@ find_tool_with_prefix() {
 find_tool_with_prefix CC gcc
 find_tool_with_prefix STRIP strip
 find_tool GDB gdb-multiarch gdb
+find_tool PYTHON3 pypy3 python3
 
 # Generate the config.mak.
 cat >config.mak <<EOF
@@ -170,7 +171,9 @@ target = $(printf %q "$target")
 
 CC = $(printf %q "$CC")
 GDB = $(printf %q "$GDB")
+PYTHON3 = $(printf %q "$PYTHON3")
 STRIP = $(printf %q "$STRIP")
+
 CFLAGS = $(printf %s "${CFLAGS:-}")
 LDFLAGS = $(printf %s "${LDFLAGS:-}")
 

--- a/configure
+++ b/configure
@@ -7,7 +7,12 @@ usage() {
 	printf >&2 'Usage: ./configure [OPTION]...\n\n'
 	printf >&2 'Defaults for the options are specified in brackets.\n'
 	printf >&2 '\nSystem:\n'
-	printf >&2 '  --arch=ARCH             build a kernel for the given architecture [%s]\n' "$arch"
+	printf >&2 '  --arch=ARCH             build for the given architecture [%s]\n' "$arch"
+	printf >&2 '  --target=TARGET         build for the given target'
+	if [[ "$has_target" != 0 ]]; then
+		printf >&2 ' [%s]' "$target"
+	fi
+	printf >&2 '\n'
 	printf >&2 '\nInstallation directories:\n'
 	printf >&2 '  --prefix=PREFIX         install to this directory [%s]\n' "$prefix"
 	printf >&2 '\nDefaults:\n'
@@ -20,11 +25,13 @@ known_arches=(riscv64)
 # shellcheck disable=SC2034 # Only accessed indirectly.
 tool_prefixes_riscv64=(riscv64-none-elf- riscv-none-elf- riscv64-unknown-elf-)
 
-args=$(getopt -n ./configure -o 'h' -l 'arch:,help,no-default-cflags,prefix:' -- "$@")
+args=$(getopt -n ./configure -o 'h' -l 'arch:,help,no-default-cflags,prefix:,target:' -- "$@")
 eval set -- "$args"
 unset args
 
 arch=riscv64
+target=
+has_target=0
 default_cflags=1
 default_ldflags=1
 help=0
@@ -63,6 +70,11 @@ while true; do
 		prefix="$2"
 		shift 2
 		;;
+	--target)
+		target="$2"
+		has_target=1
+		shift 2
+		;;
 	--)
 		shift
 		break
@@ -80,10 +92,29 @@ if [[ "$help" != 0 ]]; then
 	usage
 fi
 
+# Check that the target option is present and valid.
+if [[ "$has_target" == 0 ]]; then
+	printf >&2 './configure: the --target option is required\n'
+	printf >&2 "./configure: use \`--target list' to get a list of available targets\n"
+	exit 1
+elif [[ "$target" == list ]]; then
+	for file in "$repo/src/targets/$arch/"*.mak; do
+		basename "$file" .mak
+	done
+	exit 0
+elif [[ ! -f "$repo/src/targets/$arch/$target.mak" ]]; then
+	printf >&2 "./configure: the target \`%s' did not exist for %s\n" "$target" "$arch"
+	printf >&2 "./configure: use \`--target list' to get a list of available targets\n"
+	exit 1
+fi
+
+# Print a warning about reconfiguring.
 if [[ -e Makefile ]]; then
 	if [[ "$(realpath Makefile)" != "$(realpath "$repo/Makefile")" ]]; then
 		printf >&2 './configure: a different Makefile already exists\n'
 		exit 1
+	else
+		printf >&2 "./configure: already configured; you probably want to run \`make clean' to get rid of old build artifacts\n"
 	fi
 else
 	ln -s "$repo/Makefile" Makefile
@@ -125,6 +156,7 @@ cat >config.mak <<EOF
 arch = $(printf %q "$arch")
 prefix = $(printf %q "$prefix")
 srcdir = $(printf %q "$repo")
+target = $(printf %q "$target")
 
 CC = $(printf %q "$CC")
 STRIP = $(printf %q "$STRIP")

--- a/configure
+++ b/configure
@@ -132,24 +132,34 @@ tool_prefixes_var="tool_prefixes_${arch}[@]"
 find_tool() {
 	# Intentionally using -z, since it's not rare for people to e.g. set
 	# CC= instead of unsetting it.
-	if [[ -z "${!1:-}" ]]; then
-		for tool_prefix in "${!tool_prefixes_var}"; do
-			if command -v "$tool_prefix$2" >/dev/null 2>/dev/null; then
-				printf -v "$1" '%s%s' "$tool_prefix" "$2"
+	tool_name="$1"
+	shift
+	if [[ -z "${!tool_name:-}" ]]; then
+		for tool in "$@"; do
+			if command -v "$tool" >/dev/null 2>/dev/null; then
+				printf -v "$tool_name" '%s' "$tool"
 				break
 			fi
 		done
 	fi
-	if [[ -z "${!1:-}" ]]; then
-		printf >&2 './configure: could not find a tool for $%s\n' "$1"
+	if [[ -z "${!tool_name:-}" ]]; then
+		printf >&2 './configure: could not find a tool for $%s\n' "$tool_name"
 		exit 1
 	fi
+}
+find_tool_with_prefix() {
+	tools=()
+	for tool_prefix in "${!tool_prefixes_var}"; do
+		tools+=("$tool_prefix$2")
+	done
+	find_tool "$1" "${tools[@]}"
 }
 
 # Detect tools. Since we're expecting a freestanding compiler, we _don't_
 # assume that e.g. the default gcc is a reasonable compiler to use.
-find_tool CC gcc
-find_tool STRIP strip
+find_tool_with_prefix CC gcc
+find_tool_with_prefix STRIP strip
+find_tool GDB gdb-multiarch gdb
 
 # Generate the config.mak.
 cat >config.mak <<EOF
@@ -159,6 +169,7 @@ srcdir = $(printf %q "$repo")
 target = $(printf %q "$target")
 
 CC = $(printf %q "$CC")
+GDB = $(printf %q "$GDB")
 STRIP = $(printf %q "$STRIP")
 CFLAGS = $(printf %s "${CFLAGS:-}")
 LDFLAGS = $(printf %s "${LDFLAGS:-}")

--- a/configure
+++ b/configure
@@ -158,6 +158,7 @@ find_tool_with_prefix() {
 # Detect tools. Since we're expecting a freestanding compiler, we _don't_
 # assume that e.g. the default gcc is a reasonable compiler to use.
 find_tool_with_prefix CC gcc
+find_tool_with_prefix OBJDUMP objdump
 find_tool_with_prefix STRIP strip
 find_tool GDB gdb-multiarch gdb
 find_tool PYTHON3 pypy3 python3
@@ -171,6 +172,7 @@ target = $(printf %q "$target")
 
 CC = $(printf %q "$CC")
 GDB = $(printf %q "$GDB")
+OBJDUMP = $(printf %q "$OBJDUMP")
 PYTHON3 = $(printf %q "$PYTHON3")
 STRIP = $(printf %q "$STRIP")
 

--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -10,6 +10,6 @@
 - [Kernel]()
   - [The `print()` and `format()` functions](./kernel/print.md)
   - [Threads and Harts](./kernel/threads-and-harts.md)
-- [Targets]()
+- [Targets](./targets.md)
 - [Tutorials](./tutorials/tutorials.md)
   - [First Day](./tutorials/first-day.md)

--- a/doc/targets.md
+++ b/doc/targets.md
@@ -1,0 +1,28 @@
+# Targets
+
+Because different hardware platforms have different requirements, ukoOS supports them as different _targets_.
+
+## Milk-V Duo S
+
+The [Milk-V Duo S](https://milkv.io/duo-s) is the board we're targetting this year (academic year 2025).
+This board uses the Sophgo SG2000 SoC, which uses the T-Head C906 CPU.
+The board has 512MiB of RAM and a 1GHz CPU.
+
+The hardware kits for this year also include:
+
+- a 480x320 touchscreen
+- a 32GiB microSD card
+- a USB UART, which allows connecting to the board's serial port
+- jumper wires, to connect the touchscreen to the board
+
+## Milk-V Jupiter
+
+Some members also own devices based on the SpacemiT K1 SoC, which uses the SpacemiT X60 CPU.
+This SoC has 8 CPU cores that run at 1.6GHz.
+
+One such device is the [Milk-V Jupiter](https://milkv.io/jupiter).
+This board can have the K1, or the closely related SpacemiT M1 SoC (which runs at 2GHz, but otherwise does not significantly differ).
+This board can come with between 4GiB and 16GiB of RAM.
+
+We probably won't focus on developing drivers for this system this year, but it might make an attractive target for the future.
+It _is_ worth ensuring that the kernel doesn't do anything that breaks this board; it's far more standards-compliant than the Duo S, and future devices we use will hopefully be a lot closer to it.

--- a/doc/targets.md
+++ b/doc/targets.md
@@ -2,7 +2,7 @@
 
 Because different hardware platforms have different requirements, ukoOS supports them as different _targets_.
 
-## Milk-V Duo S
+## Milk-V Duo S (`milkv-duos`)
 
 The [Milk-V Duo S](https://milkv.io/duo-s) is the board we're targetting this year (academic year 2025).
 This board uses the Sophgo SG2000 SoC, which uses the T-Head C906 CPU.
@@ -15,7 +15,7 @@ The hardware kits for this year also include:
 - a USB UART, which allows connecting to the board's serial port
 - jumper wires, to connect the touchscreen to the board
 
-## Milk-V Jupiter
+## Milk-V Jupiter (`milkv-jupiter`)
 
 Some members also own devices based on the SpacemiT K1 SoC, which uses the SpacemiT X60 CPU.
 This SoC has 8 CPU cores that run at 1.6GHz.
@@ -26,3 +26,8 @@ This board can come with between 4GiB and 16GiB of RAM.
 
 We probably won't focus on developing drivers for this system this year, but it might make an attractive target for the future.
 It _is_ worth ensuring that the kernel doesn't do anything that breaks this board; it's far more standards-compliant than the Duo S, and future devices we use will hopefully be a lot closer to it.
+
+## QEMU RISC-V (`qemu-riscv64`)
+
+The QEMU-based emulator is its own target.
+This uses an RVA22 CPU on the virt machine, with an RTL8139 NIC.

--- a/doc/tutorials/first-day.md
+++ b/doc/tutorials/first-day.md
@@ -23,7 +23,7 @@ Once we have the code and tools, we can compile the code from the dev container
 ```shell
 mkdir build
 cd build
-../configure
+../configure --target qemu-riscv64
 make
 ```
 

--- a/doc/tutorials/hardware.md
+++ b/doc/tutorials/hardware.md
@@ -1,1 +1,0 @@
-# Hardware

--- a/flake.nix
+++ b/flake.nix
@@ -68,6 +68,7 @@
           ];
           shellHook = ''
             export CC=riscv64-none-elf-gcc
+            export OBJDUMP=riscv64-none-elf-objdump
             export STRIP=riscv64-none-elf-strip
           '';
         };

--- a/flake.nix
+++ b/flake.nix
@@ -18,29 +18,11 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
         version = "git-${self.shortRev or self.dirtyShortRev or "unknown"}";
-      in
-      rec {
-        devShells.default = pkgs.mkShell {
-          inputsFrom = [
-            packages.ukoos-riscv64
-          ];
-          nativeBuildInputs = [
-            pkgs.bear
-            pkgs.dtc
-            pkgs.minicom
-            pkgs.qemu
-          ];
-          shellHook = ''
-            export CC=riscv64-none-elf-gcc
-            export STRIP=riscv64-none-elf-strip
-          '';
-        };
 
-        packages = {
-          default = packages.ukoos-riscv64;
-
-          ukoos-riscv64 = pkgs.stdenvNoCC.mkDerivation {
-            pname = "ukoos-riscv64";
+        ukoos =
+          arch: target:
+          pkgs.stdenvNoCC.mkDerivation {
+            pname = "ukoos-${arch}-${target}";
             inherit version;
 
             src = ./.;
@@ -59,7 +41,7 @@
 
               mkdir build
               cd build
-              bash $src/configure
+              bash $src/configure --arch ${arch} --target ${target}
 
               runHook postConfigure
             '';
@@ -71,14 +53,37 @@
               runHook postInstall
             '';
           };
+      in
+      rec {
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [
+            packages.ukoos-milkv-duos
+          ];
+          nativeBuildInputs = [
+            pkgs.bear
+            pkgs.dtc
+            pkgs.minicom
+            pkgs.qemu
+          ];
+          shellHook = ''
+            export CC=riscv64-none-elf-gcc
+            export STRIP=riscv64-none-elf-strip
+          '';
+        };
+
+        packages = {
+          default = packages.ukoos-milkv-duos;
+
+          ukoos-milkv-duos = ukoos "riscv64" "milkv-duos";
+          ukoos-milkv-jupiter = ukoos "riscv64" "milkv-jupiter";
 
           dev-image-milkv-duos = pkgs.callPackage ./src/image-milkv-duos {
             dev = true;
-            inherit (packages) ukoos-riscv64 u-boot-milkv-duos;
+            inherit (packages) ukoos-milkv-duos u-boot-milkv-duos;
           };
           image-milkv-duos = pkgs.callPackage ./src/image-milkv-duos {
             dev = false;
-            inherit (packages) ukoos-riscv64 u-boot-milkv-duos;
+            inherit (packages) ukoos-milkv-duos u-boot-milkv-duos;
           };
           u-boot-milkv-duos = u-boot-milkv-duos.packages.${system}.default;
           inherit (packages.image-milkv-duos) fsbl-milkv-duos opensbi-milkv-duos;

--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,7 @@
 
           ukoos-milkv-duos = ukoos "riscv64" "milkv-duos";
           ukoos-milkv-jupiter = ukoos "riscv64" "milkv-jupiter";
+          ukoos-qemu-riscv64 = ukoos "riscv64" "qemu-riscv64";
 
           dev-image-milkv-duos = pkgs.callPackage ./src/image-milkv-duos {
             dev = true;

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
 
               mkdir build
               cd build
-              bash $src/configure --arch ${arch} --target ${target}
+              GDB=false bash $src/configure --arch ${arch} --target ${target}
 
               runHook postConfigure
             '';
@@ -62,6 +62,7 @@
           nativeBuildInputs = [
             pkgs.bear
             pkgs.dtc
+            pkgs.gdb
             pkgs.minicom
             pkgs.qemu
           ];

--- a/src/image-milkv-duos/default.nix
+++ b/src/image-milkv-duos/default.nix
@@ -10,12 +10,12 @@
   dosfstools,
   genimage,
   mtools,
-  ukoos-riscv64,
+  ukoos-milkv-duos,
 }:
 
 stdenvNoCC.mkDerivation (self: {
   pname = "image-milkv-duos" + (if dev then "-dev" else "");
-  inherit (ukoos-riscv64) version;
+  inherit (ukoos-milkv-duos) version;
 
   nativeBuildInputs = [
     dosfstools
@@ -29,7 +29,7 @@ stdenvNoCC.mkDerivation (self: {
     runHook preBuild
 
     ${lib.optionalString (!dev) ''
-      install -Dt root/boot ${ukoos-riscv64}/sys/kernel.elf
+      install -Dt root/boot ${ukoos-milkv-duos}/sys/kernel.elf
     ''}
     install -Dt root/boot ${self.passthru.fsbl-milkv-duos}/fip.bin
     mkenvimage -s 0x20000 -o root/boot/uboot.env ${./u-boot.txt}

--- a/src/kernel/arch/riscv64/include.mak
+++ b/src/kernel/arch/riscv64/include.mak
@@ -25,7 +25,7 @@ $(call defcleanable, \
 
 # Targets for booting and debugging the kernel.
 gdb: src/kernel/kernel.sym
-	gdb-multiarch src/kernel/kernel.sym \
+	$(GDB) src/kernel/kernel.sym \
 		-ex "set substitute-path / $(srcdir)/" \
 		-ex "layout src" \
 		-ex "focus cmd" \
@@ -34,7 +34,7 @@ gdb: src/kernel/kernel.sym
 		-ex "break _panic_halt" \
 		-ex "break unrecoverable_exception"
 gdb_bootstub: src/kernel/kernel.sym
-	gdb-multiarch src/kernel/kernel.sym \
+	$(GDB) src/kernel/kernel.sym \
 		-ex "set substitute-path / $(srcdir)/" \
 		-ex "layout asm" \
 		-ex "layout regs" \

--- a/src/kernel/arch/riscv64/include.mak
+++ b/src/kernel/arch/riscv64/include.mak
@@ -44,8 +44,6 @@ gdb_bootstub: src/kernel/kernel.sym
 		-ex "break main"
 qemu: src/kernel/kernel.elf
 	qemu-system-riscv64 \
-		--machine virt \
-		--smp 1 \
 		-m 1G \
 		-nographic \
 		-kernel src/kernel/kernel.elf \
@@ -53,13 +51,11 @@ qemu: src/kernel/kernel.elf
 		$(QEMUFLAGS)
 qemu-debug: src/kernel/kernel.elf
 	qemu-system-riscv64 \
-		--machine virt \
-		--cpu rva22s64 \
-		--smp 1 \
 		-m 1G \
 		-nographic \
 		-kernel src/kernel/kernel.elf \
 		-s -S \
+		$(target-qemuflags) \
 		$(QEMUFLAGS)
 .PHONY: gdb gdb_bootstub qemu qemu-debug
 

--- a/src/kernel/arch/riscv64/include.mak
+++ b/src/kernel/arch/riscv64/include.mak
@@ -59,6 +59,11 @@ qemu-debug: src/kernel/kernel.elf
 		$(QEMUFLAGS)
 .PHONY: gdb gdb_bootstub qemu qemu-debug
 
+# A target for dumping the kernel.
+objdump: src/kernel/arch/riscv64/kernel-unstripped.elf
+	$(OBJDUMP) -d src/kernel/arch/riscv64/kernel-unstripped.elf | less
+.PHONY: objdump
+
 # Link the kernel. This kernel will have debug symbols, and not actually be
 # bootable -- it depends on being loaded by and having the boot environment set
 # up by the bootstub.

--- a/src/kernel/arch/riscv64/include.mak
+++ b/src/kernel/arch/riscv64/include.mak
@@ -32,7 +32,8 @@ gdb: src/kernel/kernel.sym
 		-ex "focus cmd" \
 		-ex "target remote :1234" \
 		-ex "break main" \
-		-ex "break _panic_halt"
+		-ex "break _panic_halt" \
+		-ex "break unrecoverable_exception"
 gdb_bootstub: src/kernel/kernel.sym
 	gdb-multiarch src/kernel/kernel.sym \
 		-ex "set substitute-path / $(srcdir)/" \

--- a/src/kernel/arch/riscv64/include.mak
+++ b/src/kernel/arch/riscv64/include.mak
@@ -2,7 +2,6 @@ kernel-cflags += \
 	-DARCH_RISCV64 \
 	-fno-omit-frame-pointer \
 	-mabi=lp64 \
-	-march=rv64imac_zicsr_zicntr_zihpm_zba_zbb_zbs_zihintpause_zicbom_zicbop_zicboz \
 	-mcmodel=medany
 kernel-objs-asm += arch/riscv64/start
 kernel-objs-c += arch/riscv64/backtrace arch/riscv64/hart_locals arch/riscv64/paging arch/riscv64/panic arch/riscv64/sbi
@@ -46,11 +45,11 @@ gdb_bootstub: src/kernel/kernel.sym
 qemu: src/kernel/kernel.elf
 	qemu-system-riscv64 \
 		--machine virt \
-		--cpu rva22s64 \
 		--smp 1 \
 		-m 1G \
 		-nographic \
 		-kernel src/kernel/kernel.elf \
+		$(target-qemuflags) \
 		$(QEMUFLAGS)
 qemu-debug: src/kernel/kernel.elf
 	qemu-system-riscv64 \

--- a/src/kernel/arch/riscv64/include.mak
+++ b/src/kernel/arch/riscv64/include.mak
@@ -44,14 +44,12 @@ gdb_bootstub: src/kernel/kernel.sym
 		-ex "break main"
 qemu: src/kernel/kernel.elf
 	qemu-system-riscv64 \
-		-m 1G \
 		-nographic \
 		-kernel src/kernel/kernel.elf \
 		$(target-qemuflags) \
 		$(QEMUFLAGS)
 qemu-debug: src/kernel/kernel.elf
 	qemu-system-riscv64 \
-		-m 1G \
 		-nographic \
 		-kernel src/kernel/kernel.elf \
 		-s -S \

--- a/src/kernel/arch/riscv64/include.mak
+++ b/src/kernel/arch/riscv64/include.mak
@@ -85,7 +85,7 @@ src/kernel/kernel.sym: src/kernel/arch/riscv64/kernel-unstripped.elf
 src/kernel/arch/riscv64/bootstub_generated.S: $(srcdir)/src/kernel/arch/riscv64/generate_bootstub.py src/kernel/arch/riscv64/kernel.elf
 	@mkdir -p $(dir $@)
 	@echo "GEN     $@"
-	$(Q)python3 $(srcdir)/src/kernel/arch/riscv64/generate_bootstub.py src/kernel/arch/riscv64/kernel-unstripped.elf $@
+	$(Q)$(PYTHON3) $(srcdir)/src/kernel/arch/riscv64/generate_bootstub.py src/kernel/arch/riscv64/kernel-unstripped.elf $@
 
 # Compile the bootstub.
 src/kernel/arch/riscv64/bootstub_generated.o: src/kernel/arch/riscv64/bootstub_generated.S

--- a/src/kernel/arch/riscv64/start.S
+++ b/src/kernel/arch/riscv64/start.S
@@ -33,25 +33,90 @@ _start:
 .global unrecoverable_exception
 .type unrecoverable_exception, @function
 unrecoverable_exception:
-	mv s1, ra
+	# Stash s0 into SSCRATCH for now. We don't print SSCRATCH or depend on
+	# its value, so it's fine to just clobber it.
+	csrw sscratch, s0
+
+	# Stash all the registers into unrecoverable_exception_registers,
+	# except s0 (since we clobbered it).
+	la s0, unrecoverable_exception_registers
+	sd ra, 0(s0)
+	sd sp, 8(s0)
+	sd gp, 16(s0)
+	sd tp, 24(s0)
+	sd t0, 32(s0)
+	sd t1, 40(s0)
+	sd t2, 48(s0)
+	# Skip s0 for now.
+	sd s1, 64(s0)
+	sd a0, 72(s0)
+	sd a1, 80(s0)
+	sd a2, 88(s0)
+	sd a3, 96(s0)
+	sd a4, 104(s0)
+	sd a5, 112(s0)
+	sd a6, 120(s0)
+	sd a7, 128(s0)
+	sd s2, 136(s0)
+	sd s3, 144(s0)
+	sd s4, 152(s0)
+	sd s5, 160(s0)
+	sd s6, 168(s0)
+	sd s7, 176(s0)
+	sd s8, 184(s0)
+	sd s9, 192(s0)
+	sd s10, 200(s0)
+	sd s11, 208(s0)
+	sd t3, 216(s0)
+	sd t4, 224(s0)
+	sd t5, 232(s0)
+	sd t6, 240(s0)
+
+	# Get the old value of s0 back, then store it.
+	csrr a0, sscratch
+	sd a0, 56(s0)
+
+	# Print the "BLUF" registers: SEPC (printed as PC), RA, SCAUSE, STVAL.
 	la a0, unrecoverable_exception_msg0
 	call unrecoverable_exception_print_cstr
 	csrr a0, sepc
 	call unrecoverable_exception_print_hex
+
 	la a0, unrecoverable_exception_msg1
 	call unrecoverable_exception_print_cstr
-	mv a0, s1
+	ld a0, (s0)
 	call unrecoverable_exception_print_hex
+
 	la a0, unrecoverable_exception_msg2
 	call unrecoverable_exception_print_cstr
 	csrr a0, scause
 	call unrecoverable_exception_print_hex
+
 	la a0, unrecoverable_exception_msg3
 	call unrecoverable_exception_print_cstr
 	csrr a0, stval
 	call unrecoverable_exception_print_hex
+
+	# Print all the registers, in a denser format.
+	la s1, unrecoverable_exception_gpr_msgs
+	mv s2, zero
+1:
+	add a0, s1, s2
+	ld a0, (a0)
+	call unrecoverable_exception_print_cstr
+	add a0, s0, s2
+	ld a0, (a0)
+	call unrecoverable_exception_print_hex
+
+	addi s2, s2, 8
+	addi a0, s2, -248
+	bnez a0, 1b
+
+	# Print that we're halting, then halt.
 	la a0, unrecoverable_exception_msg4
 	call unrecoverable_exception_print_cstr
+
+	# Halt.
 	tail _panic_halt
 
 .type unrecoverable_exception_print_cstr, @function
@@ -87,13 +152,19 @@ unrecoverable_exception_print_hex:
 2:
 	ret
 
+.section .data
+
+unrecoverable_exception_registers: .zero 248
+
 .section .rodata
 
 unrecoverable_exception_digits:
 	.ascii "0123456789abcdef"
 unrecoverable_exception_msg0:
-	.ascii "ukoOS: Got an unrecoverable exception!"
 	.byte 13, 10
+	.byte 13, 10
+	.ascii "ukoOS: Got an unrecoverable exception!"
+	.byte 13, 10, 13, 10
 	.ascii "    PC: 0x"
 	.byte 0
 unrecoverable_exception_msg1:
@@ -109,4 +180,135 @@ unrecoverable_exception_msg3:
 	.ascii " STVAL: 0x"
 	.byte 0
 unrecoverable_exception_msg4:
-	.byte 13, 10, 0
+	.byte 13, 10, 13, 10
+	.ascii "Halting..."
+	.byte 13, 10
+	.byte 0
+
+unrecoverable_exception_gpr_msgs:
+	.quad unrecoverable_exception_ra
+	.quad unrecoverable_exception_sp, unrecoverable_exception_gp
+	.quad unrecoverable_exception_tp, unrecoverable_exception_t0
+	.quad unrecoverable_exception_t1, unrecoverable_exception_t2
+	.quad unrecoverable_exception_s0, unrecoverable_exception_s1
+	.quad unrecoverable_exception_a0, unrecoverable_exception_a1
+	.quad unrecoverable_exception_a2, unrecoverable_exception_a3
+	.quad unrecoverable_exception_a4, unrecoverable_exception_a5
+	.quad unrecoverable_exception_a6, unrecoverable_exception_a7
+	.quad unrecoverable_exception_s2, unrecoverable_exception_s3
+	.quad unrecoverable_exception_s4, unrecoverable_exception_s5
+	.quad unrecoverable_exception_s6, unrecoverable_exception_s7
+	.quad unrecoverable_exception_s8, unrecoverable_exception_s9
+	.quad unrecoverable_exception_s10, unrecoverable_exception_s11
+	.quad unrecoverable_exception_t3, unrecoverable_exception_t4
+	.quad unrecoverable_exception_t5, unrecoverable_exception_t6
+
+unrecoverable_exception_ra:
+	.byte 13, 10, 13, 10
+	.ascii "ZERO: 0x0000000000000000   RA: 0x"
+	.byte 0
+unrecoverable_exception_sp:
+	.byte 13, 10
+	.ascii "  SP: 0x"
+	.byte 0
+unrecoverable_exception_gp:
+	.ascii "   GP: 0x"
+	.byte 0
+unrecoverable_exception_tp:
+	.byte 13, 10
+	.ascii "  TP: 0x"
+	.byte 0
+unrecoverable_exception_t0:
+	.ascii "   T0: 0x"
+	.byte 0
+unrecoverable_exception_t1:
+	.byte 13, 10
+	.ascii "  T1: 0x"
+	.byte 0
+unrecoverable_exception_t2:
+	.ascii "   T2: 0x"
+	.byte 0
+unrecoverable_exception_s0:
+	.byte 13, 10
+	.ascii "  S0: 0x"
+	.byte 0
+unrecoverable_exception_s1:
+	.ascii "   S1: 0x"
+	.byte 0
+unrecoverable_exception_a0:
+	.byte 13, 10
+	.ascii "  A0: 0x"
+	.byte 0
+unrecoverable_exception_a1:
+	.ascii "   A1: 0x"
+	.byte 0
+unrecoverable_exception_a2:
+	.byte 13, 10
+	.ascii "  A2: 0x"
+	.byte 0
+unrecoverable_exception_a3:
+	.ascii "   A3: 0x"
+	.byte 0
+unrecoverable_exception_a4:
+	.byte 13, 10
+	.ascii "  A4: 0x"
+	.byte 0
+unrecoverable_exception_a5:
+	.ascii "   A5: 0x"
+	.byte 0
+unrecoverable_exception_a6:
+	.byte 13, 10
+	.ascii "  A6: 0x"
+	.byte 0
+unrecoverable_exception_a7:
+	.ascii "   A7: 0x"
+	.byte 0
+unrecoverable_exception_s2:
+	.byte 13, 10
+	.ascii "  S2: 0x"
+	.byte 0
+unrecoverable_exception_s3:
+	.ascii "   S3: 0x"
+	.byte 0
+unrecoverable_exception_s4:
+	.byte 13, 10
+	.ascii "  S4: 0x"
+	.byte 0
+unrecoverable_exception_s5:
+	.ascii "   S5: 0x"
+	.byte 0
+unrecoverable_exception_s6:
+	.byte 13, 10
+	.ascii "  S6: 0x"
+	.byte 0
+unrecoverable_exception_s7:
+	.ascii "   S7: 0x"
+	.byte 0
+unrecoverable_exception_s8:
+	.byte 13, 10
+	.ascii "  S8: 0x"
+	.byte 0
+unrecoverable_exception_s9:
+	.ascii "   S9: 0x"
+	.byte 0
+unrecoverable_exception_s10:
+	.byte 13, 10
+	.ascii " S10: 0x"
+	.byte 0
+unrecoverable_exception_s11:
+	.ascii "  S11: 0x"
+	.byte 0
+unrecoverable_exception_t3:
+	.byte 13, 10
+	.ascii "  T3: 0x"
+	.byte 0
+unrecoverable_exception_t4:
+	.ascii "   T4: 0x"
+	.byte 0
+unrecoverable_exception_t5:
+	.byte 13, 10
+	.ascii "  T5: 0x"
+	.byte 0
+unrecoverable_exception_t6:
+	.ascii "   T6: 0x"
+	.byte 0

--- a/src/kernel/builtins/strcmp.c
+++ b/src/kernel/builtins/strcmp.c
@@ -1,0 +1,16 @@
+#include <types.h>
+
+[[gnu::nonnull(1, 2), gnu::pure]]
+int strcmp(const char *s1, const char *s2) {
+  u8 c1, c2;
+  for (;;) {
+    c1 = *s1++;
+    c2 = *s2++;
+
+    if (c1 != c2)
+      break;
+    if (!c1)
+      break;
+  }
+  return c1 - c2;
+}

--- a/src/kernel/include.mak
+++ b/src/kernel/include.mak
@@ -8,8 +8,11 @@ kernel-cflags = $(CFLAGS) \
 	-isystem $(srcdir)/src/kernel/arch/$(arch)/include \
 	-nostdlib \
 	-std=c23 \
+	-Walloca \
 	-Wconversion \
-	-Wsystem-headers
+	-Wsystem-headers \
+	-Wvla \
+	-Wwrite-strings
 kernel-cflags += -fdata-sections -ffunction-sections
 kernel-ldflags += -Wl,--gc-sections
 kernel-dir = src/kernel

--- a/src/kernel/include.mak
+++ b/src/kernel/include.mak
@@ -18,7 +18,7 @@ kernel-ldflags += -Wl,--gc-sections
 kernel-dir = src/kernel
 kernel-objs-asm =
 kernel-objs-c = devicetree main panic print random selftest swar_test symbolicate
-kernel-objs-c += builtins/bzero builtins/explicit_bzero builtins/memcpy builtins/memcmp builtins/memset builtins/strlen
+kernel-objs-c += builtins/bzero builtins/explicit_bzero builtins/memcpy builtins/memcmp builtins/memset builtins/strcmp builtins/strlen
 kernel-objs-c += crypto/subtle/rfc7539 crypto/subtle/rfc7693
 kernel-objs-c += mm/alloc mm/physical_alloc mm/virtual_alloc
 include $(srcdir)/src/kernel/arch/$(arch)/include.mak

--- a/src/kernel/include/compiler.h
+++ b/src/kernel/include/compiler.h
@@ -139,6 +139,9 @@ void *memset(void *restrict dst, int byte, __SIZE_TYPE__ len);
 [[gnu::nonnull(1, 2), gnu::pure]]
 int memcmp(const void *s1, const void *s2, __SIZE_TYPE__ n);
 
+[[gnu::nonnull(1, 2), gnu::pure]]
+int strcmp(const char *s1, const char *s2);
+
 [[gnu::nonnull(1), gnu::pure]]
 __SIZE_TYPE__ strlen(const char *s);
 

--- a/src/kernel/include/mm/alloc.h
+++ b/src/kernel/include/mm/alloc.h
@@ -31,6 +31,27 @@ alloc(usize size);
 zalloc(usize size);
 
 /**
+ * Allocates a copy of an object.
+ */
+[[gnu::alloc_size(2), gnu::malloc, gnu::malloc(free, 1),
+  nodiscard]] static void *
+memdup(const void *ptr, usize len) {
+  char *out = alloc(len);
+  if (!out)
+    return nullptr;
+  return memcpy(out, ptr, len);
+}
+
+/**
+ * Allocates a string, which is the same length as `str` and initialized to have
+ * the same contents.
+ */
+[[gnu::malloc, gnu::malloc(free, 1), nodiscard]] static char *
+strdup(const char *str) {
+  return memdup(str, strlen(str) + 1);
+}
+
+/**
  * Allocates memory, initializing it with the contents of `ptr`, which is then
  * `free`d. On OOM, returns `nullptr` and does *not* free `ptr`.
  *

--- a/src/kernel/print.c
+++ b/src/kernel/print.c
@@ -61,6 +61,8 @@ static void vfprint(struct formatter *fmt, const char *format, va_list ap);
 typedef void (*format_func)(struct formatter *fmt, const char *args_start,
                             const char *args_end, va_list *ap);
 
+const char *NUMBER_ALPHABET = "0123456789abcdef";
+
 static void format_number(struct formatter *fmt, const char *args_start,
                           const char *args_end, bool sign, u64 number) {
   // Parse arguments.
@@ -122,7 +124,6 @@ static void format_number(struct formatter *fmt, const char *args_start,
 
   // Format the number to the buffer, backwards. This needs a special case for
   // zero, which we'd otherwise terminate on.
-  const char *alphabet = "0123456789abcdef";
   char buf_rev[64];
   usize buf_len = 0;
   if (number == 0) {
@@ -130,7 +131,7 @@ static void format_number(struct formatter *fmt, const char *args_start,
     buf_len = 1;
   } else {
     while (number) {
-      buf_rev[buf_len++] = alphabet[number % base];
+      buf_rev[buf_len++] = NUMBER_ALPHABET[number % base];
       number /= base;
     }
   }
@@ -185,6 +186,25 @@ static void format_bool(struct formatter *fmt, const char *args_start,
   }
 
   write_str(fmt, va_arg(*ap, int) ? "true" : "false");
+}
+
+static void format_bytes(struct formatter *fmt, const char *args_start,
+                         const char *args_end, va_list *ap) {
+  if (args_start != args_end) {
+    write_str(fmt, "{{invalid arguments for type bytes: ");
+    write_stri(fmt, args_start, args_end);
+    write_str(fmt, "}}");
+    return;
+  }
+
+  const u8 *ptr = va_arg(*ap, const u8 *);
+  usize len = va_arg(*ap, usize);
+  for (usize i = 0; i < len; i++) {
+    if (i)
+      write_byte(fmt, ' ');
+    write_byte(fmt, NUMBER_ALPHABET[ptr[i] >> 4]);
+    write_byte(fmt, NUMBER_ALPHABET[ptr[i] & 15]);
+  }
 }
 
 static void format_cstr(struct formatter *fmt, const char *args_start,
@@ -343,6 +363,8 @@ static format_func find_format_func(const char *type_name_ptr,
       return format_uptr;
     break;
   case 5:
+    if (!memcmp(type_name_ptr, "bytes", 5))
+      return format_bytes;
     if (!memcmp(type_name_ptr, "isize", 5))
       return format_isize;
     if (!memcmp(type_name_ptr, "paddr", 5))

--- a/src/targets/riscv64/milkv-duos.mak
+++ b/src/targets/riscv64/milkv-duos.mak
@@ -1,2 +1,2 @@
 kernel-cflags += -march=rv64imac_xtheadba_xtheadbb_xtheadbs_xtheadcmo_xtheadcondmov_xtheadfmemidx_xtheadmac_xtheadmemidx_xtheadmempair_xtheadsync_zicsr_zicntr_zihpm -mtune=thead-c906
-target-qemuflags = --machine virt --cpu thead-c906 --smp 1
+target-qemuflags = --machine virt --cpu thead-c906 --smp 1 -m 512M

--- a/src/targets/riscv64/milkv-duos.mak
+++ b/src/targets/riscv64/milkv-duos.mak
@@ -1,2 +1,2 @@
 kernel-cflags += -march=rv64imac_xtheadba_xtheadbb_xtheadbs_xtheadcmo_xtheadcondmov_xtheadfmemidx_xtheadmac_xtheadmemidx_xtheadmempair_xtheadsync_zicsr_zicntr_zihpm -mtune=thead-c906
-target-qemuflags = --cpu thead-c906
+target-qemuflags = --machine virt --cpu thead-c906 --smp 1

--- a/src/targets/riscv64/milkv-duos.mak
+++ b/src/targets/riscv64/milkv-duos.mak
@@ -1,0 +1,2 @@
+kernel-cflags += -march=rv64imac_xtheadba_xtheadbb_xtheadbs_xtheadcmo_xtheadcondmov_xtheadfmemidx_xtheadmac_xtheadmemidx_xtheadmempair_xtheadsync_zicsr_zicntr_zihpm -mtune=thead-c906
+target-qemuflags = --cpu thead-c906

--- a/src/targets/riscv64/milkv-jupiter.mak
+++ b/src/targets/riscv64/milkv-jupiter.mak
@@ -1,2 +1,2 @@
 kernel-cflags += -march=rv64imac_zicsr_zicntr_zihpm_zba_zbb_zbs_zihintpause_zicbom_zicbop_zicboz
-target-qemuflags = --cpu rva22s64
+target-qemuflags = --machine virt --cpu rva22s64 --smp 8

--- a/src/targets/riscv64/milkv-jupiter.mak
+++ b/src/targets/riscv64/milkv-jupiter.mak
@@ -1,0 +1,2 @@
+kernel-cflags += -march=rv64imac_zicsr_zicntr_zihpm_zba_zbb_zbs_zihintpause_zicbom_zicbop_zicboz
+target-qemuflags = --cpu rva22s64

--- a/src/targets/riscv64/milkv-jupiter.mak
+++ b/src/targets/riscv64/milkv-jupiter.mak
@@ -1,2 +1,2 @@
 kernel-cflags += -march=rv64imac_zicsr_zicntr_zihpm_zba_zbb_zbs_zihintpause_zicbom_zicbop_zicboz
-target-qemuflags = --machine virt --cpu rva22s64 --smp 8
+target-qemuflags = --machine virt --cpu rva22s64 --smp 8 -m 4G

--- a/src/targets/riscv64/qemu-riscv64.mak
+++ b/src/targets/riscv64/qemu-riscv64.mak
@@ -1,0 +1,2 @@
+kernel-cflags += -march=rv64imac_zicsr_zicntr_zihpm_zba_zbb_zbs_zihintpause_zicbom_zicbop_zicboz
+target-qemuflags = --machine virt --cpu rva22s64 --smp 1 --netdev user,id=net0 -device rtl8139,netdev=net0,bus=pcie.0

--- a/src/targets/riscv64/qemu-riscv64.mak
+++ b/src/targets/riscv64/qemu-riscv64.mak
@@ -1,2 +1,2 @@
 kernel-cflags += -march=rv64imac_zicsr_zicntr_zihpm_zba_zbb_zbs_zihintpause_zicbom_zicbop_zicboz
-target-qemuflags = --machine virt --cpu rva22s64 --smp 1 --netdev user,id=net0 -device rtl8139,netdev=net0,bus=pcie.0
+target-qemuflags = --machine virt --cpu rva22s64 --smp 1 -m 1G --netdev user,id=net0 -device rtl8139,netdev=net0,bus=pcie.0


### PR DESCRIPTION
Resolves #25.

Initially, adds:

- `milkv-duos`: The board we're using.
- `milkv-jupiter`: An RVA22 board, a couple UKO members have one.
- `qemu-riscv64`: QEMU configured for RVA22 plus an RTL8139.

Also has a bit of a grab-bag of other minor changes...

- Adds [`unrecoverable_exception`](https://github.com/UMN-Kernel-Object/ukoos/blob/a61301133fd63fd945d61abd4ca7ec49e4bc2f27/src/kernel/arch/riscv64/start.S#L35) to the list of breakpoints we make by default, and makes it print all the GPRs. (Resolves #5.)
- Detects gdb instead of assuming it's named `gdb-multiarch`.
- Enables a few more warnings.
- Implements a few more string functions.
- Adds the `{bytes}` format directive.
- Adds `make objdump`, to dump the kernel's code.