### PR TITLE
Apply SPDX markings to more files.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 name: Build ukoOS
 on:
   push:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 name: Deploy documentation
 on:
   push:

--- a/.github/workflows/reuse-lint.yml
+++ b/.github/workflows/reuse-lint.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 name: REUSE linting
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+#
+# SPDX-License-Identifier: CC0-1.0
+
 *.d
 *.o
 doc/book/

--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ Files may be marked individually, but broadly speaking (in a non-binding and imp
 
 - The code is offered under the GPL 3.0 or later, the same as GNU coreutils.
 - Documentation is dual-licensed under the GFDL and CC-BY-SA, the same as Wikipedia.
-- CI configurations and similar "miscellanous files" are licensed CC0-1.0, which is approximately public-domain.
+- Some generated and miscellanous files are licensed CC0-1.0, which is approximately public-domain.
 
 This can be checked with `reuse lint`, with the [REUSE tool](https://reuse.software/).

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,7 +1,7 @@
 version = 1
 
 [[annotations]]
-path = [".devcontainer/devcontainer.json", ".github/workflows/*.yml", "**.nix", "src/image-milkv-duos-sd/genimage.cfg", "src/image-milkv-duos-sd/u-boot.txt"]
+path = [".devcontainer/devcontainer.json", "src/image-milkv-duos-sd/u-boot.txt"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2025 ukoOS Contributors"
 SPDX-License-Identifier = "GPL-3.0-or-later"
@@ -13,7 +13,7 @@ SPDX-FileCopyrightText = "2025 ukoOS Contributors"
 SPDX-License-Identifier = "CC-BY-SA-4.0 OR GFDL-1.3-or-later"
 
 [[annotations]]
-path = [".gitignore", ".mailmap", "flake.lock"]
+path = ["flake.lock"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2025 ukoOS Contributors"
 SPDX-License-Identifier = "CC0-1.0"

--- a/flake.nix
+++ b/flake.nix
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 {
   inputs.u-boot-milkv-duos-sd = {
     url = "github:UMN-Kernel-Object/u-boot/milkv-duos-sd";

--- a/src/image-milkv-duos-sd/default.nix
+++ b/src/image-milkv-duos-sd/default.nix
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 {
   dev ? false,
   u-boot-milkv-duos-sd,

--- a/src/image-milkv-duos-sd/fsbl.nix
+++ b/src/image-milkv-duos-sd/fsbl.nix
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 {
   opensbi,
   u-boot,

--- a/src/image-milkv-duos-sd/genimage.cfg
+++ b/src/image-milkv-duos-sd/genimage.cfg
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 image ukoos.img {
 	hdimage {
 		partition-table-type = "mbr"

--- a/src/image-milkv-duos-sd/opensbi.nix
+++ b/src/image-milkv-duos-sd/opensbi.nix
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 {
   u-boot,
 


### PR DESCRIPTION
This removes a few cases that I special-cased in the REUSE.toml because I was too lazy to put the actual headers in. This isn't ideal, because then people who copy those files are wondering how they pass the CI job if they're not familiar with REUSE.toml.

Also fixes the README claiming that CI configs are CC0, when they're actually GPL3.