### PR TITLE
fix: run devcontainer privileged 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,5 @@
       }
     }
   },
-  "runArgs": [
-    "--network=host"
-  ]
+  "runArgs": ["--network=host", "--privileged"]
 }


### PR DESCRIPTION
This enabled ttyUSB* devices to be passed through to the dev container, so we can access the board from there.