### PR TITLE
Device model

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+# SPDX-FileCopyrightText: ukoOS Contributors
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+# SPDX-FileCopyrightText: ukoOS Contributors
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 ukoOS Contributors
+# SPDX-FileCopyrightText: ukoOS Contributors
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 ukoOS Contributors
+# SPDX-FileCopyrightText: ukoOS Contributors
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+# SPDX-FileCopyrightText: ukoOS Contributors
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+# SPDX-FileCopyrightText: ukoOS Contributors
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+# SPDX-FileCopyrightText: ukoOS Contributors
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/configure
+++ b/configure
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+# SPDX-FileCopyrightText: ukoOS Contributors
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -9,6 +9,7 @@
   - [Using GDB](./getting-started/using-gdb.md)
 - [Kernel]()
   - [The `print()` and `format()` functions](./kernel/print.md)
+  - [Init Functions](./kernel/init.md)
   - [Threads and Harts](./kernel/threads-and-harts.md)
   - [Memory management]()
     - [Overview](./kernel/mm/overview.md)

--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -10,6 +10,7 @@
 - [Kernel]()
   - [The `print()` and `format()` functions](./kernel/print.md)
   - [Init Functions](./kernel/init.md)
+  - [Devices](./kernel/devices.md)
   - [Threads and Harts](./kernel/threads-and-harts.md)
   - [Memory management]()
     - [Overview](./kernel/mm/overview.md)

--- a/doc/book.toml
+++ b/doc/book.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+# SPDX-FileCopyrightText: ukoOS Contributors
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/doc/include.mak
+++ b/doc/include.mak
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+# SPDX-FileCopyrightText: ukoOS Contributors
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/doc/kernel/devices.md
+++ b/doc/kernel/devices.md
@@ -9,8 +9,8 @@ For example, it allows representing that one cannot (safely) disable a PCIe port
 
 ## Device classes
 
-Each device probably provides some functionality other than simply existing.
-These bits of functionality can be lumped into a "device class."
+Devices provide functionality other than simply existing.
+These bits of functionality can be lumped into "device classes."
 Device classes are not a single construct in the code, but are a design pattern in the kernel.
 
 Typically, a device class consists of three things: a vtable struct, a device struct, and a list of devices.

--- a/doc/kernel/devices.md
+++ b/doc/kernel/devices.md
@@ -1,0 +1,221 @@
+# Devices
+
+Devices that have been detected are represented as a tree of `struct device` in memory.
+(This should not be confused with the [Devicetree](https://en.wikipedia.org/wiki/Devicetree) standard, which is one of several ways that ukoOS populates this tree.)
+
+This tree's root node is stored in a global (`root_device`, declared in `device.h`).
+The main purpose of this tree is to act as the single owner for all devices, in a way that allows describing dependencies between a device and the controller for the bus that it's on.
+For example, it allows representing that one cannot (safely) disable a PCIe port with a card plugged into it, without first disabling that card.
+
+## Device classes
+
+Each device probably provides some functionality other than simply existing.
+These bits of functionality can be lumped into a "device class."
+Device classes are not a single construct in the code, but are a design pattern in the kernel.
+
+Typically, a device class consists of three things: a vtable struct, a device struct, and a list of devices.
+
+The vtable is simply a struct with methods for that kind of device.
+An example might be:
+
+```c
+struct rgb_led_ops {
+  int get_colors(struct rgb_led *this, u8 *out_r, u8 *out_g, u8 *out_b);
+  int set_colors(struct rgb_led *this, u8 r, u8 g, u8 b);
+  int get_relative_brightness(struct rgb_led *this, u32 *out_r,
+                              u32 *out_g, u32 *out_b);
+};
+```
+
+A device struct is a struct that can be linked into the list of devices.
+
+```c
+struct rgb_led {
+  struct list_head list;
+  const struct rgb_led_ops *ops;
+  // any fields that make sense
+
+  // maybe including a ptr to the _same_ device
+  struct device *device;
+};
+```
+
+The device list is just a global list head that can have instances of the device class pushed onto it.
+
+```c
+struct list_head rgb_leds;
+```
+
+## Device discovery and creation
+
+Devices can be created and attached to the tree of devices at runtime, not just during boot.
+There are a few interesting points to look at during boot, though.
+
+1. Early in boot (as soon as the allocator is up), drivers register themselves with device classes they can detect devices on.
+
+   For example, a hypothetical ACME LED driver might contain code like:
+
+   ```c
+   struct acme_led_regs {
+     u8 r, g, b;
+     u8 rsvd0;
+     u8 flags, flags_set, flags_clr;
+     u8 rsvd1;
+   };
+
+   struct acme_led {
+     struct device device;
+     struct rgb_led rgb_led;
+     struct acme_led_regs *regs;
+   };
+
+   // Defined later in this documentation.
+   static int acme_led_get_colors(struct rgb_led *rgb_led, u8 *out_r, u8 *out_g, u8 *out_b);
+
+   static const struct rgb_led_ops acme_led_ops = {
+     .get_colors = acme_led_get_colors,
+     // ...and so on...
+   };
+
+   // Defined later in this documentation.
+   static struct device *acme_led_enumerate_dt(struct devicetree_node *node);
+
+   // I don't really know what enumerating with other device classes would look
+   // like; this is just an example.
+   static struct device *acme_led_enumerate_usb(/* ... */) { /* ... */ }
+
+   DEFINE_INIT(INIT_REGISTER_DRIVERS) {
+     devicetree_register("acme0142", acme_led_enumerate_dt);
+     devicetree_register("acme,ledrgb", acme_led_enumerate_dt);
+     usb_register(0x1234, 0x5678, acme_led_enumerate_usb);
+   }
+   ```
+
+   Registering a callback for the driver just populates a table to be used in later steps.
+   (In the future, this might even get moved to compile-time so the allocator isn't necessary and lookups can be accelerated with [gperf](https://www.gnu.org/software/gperf/).)
+
+2. At some point later, those table entries get used, and the appropriate functions get called.
+
+   The Devicetree, for example, can get traversed as soon as all the drivers are registered, since it's already been parsed as part of setting up the allocator.
+   Buses like PCI or USB might wait until a later point to be traversed, or might even be traversed multiple times in order to handle hotplug.
+
+   For the sake of our running example, let's say the Devicetree node looks like:
+
+   ```dts
+   rgb0@45670000 {
+     compatible = "acme0142", "generic-rgb-led";
+     reg = <0x00000000 0x45670000
+            0x00000000 0x00001000>;
+   }
+   ```
+
+   At some point during boot, the `devicetree_enumerate()` function will get called.
+   This function will walk the tree and look on each node for a `compatible` property.
+   If one is found, it'll call the callback (`acme_led_enumerate_dt` in thie case) and pass it the node.
+
+3. When a callback is called, it creates the device object.
+
+   `acme_led_enumerate_dt` might look something like:
+
+   ```c
+   static struct device *acme_led_enumerate_dt(struct devicetree_node *node) {
+     struct acme_led *led = nullptr;
+     paddr reg_addr;
+     usize reg_size;
+
+     // Grab the information we need to create the device from its Devicetree
+     // node.
+     if (!devicetree_reg(node, &reg_addr, &reg_size))
+       goto fail;
+     if (reg_size < sizeof(struct acme_led_regs));
+       goto fail;
+
+     // Allocate the device object.
+     struct acme_led *led = alloc(sizeof(struct acme_led));
+     if (!led)
+       goto fail;
+
+     // Initialize the device object.
+     *led = (struct acme_led) {
+       .device = DEVICE_INIT(led->device, "acme_led@{paddr}", reg_addr),
+       .rgb_led = {
+         .list = LIST_INIT(led->rgb_led.list),
+         .ops = &acme_led_ops,
+         .device = &led->device,
+       },
+       .regs = iomem_map(reg_addr, reg_size),
+     };
+     if (!led->device.name || !led->regs)
+       goto fail;
+
+     // Store the device in the appropriate global data structures. The device
+     // will get stored in the tree of devices once it gets returned.
+     list_push(&rgb_leds, &led->rgb_led.list);
+
+     return led;
+
+   fail:
+     if (led) {
+       free(led->device.name);
+       iomem_unmap(led->regs, reg_size);
+     }
+     free(led);
+     return nullptr;
+   }
+   ```
+
+4. As various buses are discovered, their enumerate functions are called too.
+   For example, after `devicetree_enumerate` returns, `pci_enumerate` might be called to find devices on the PCIe bus that was discovered in the Devicetree.
+   Later, `usb_enumerate` might be called to find devices on USB ports discovered in the Devicetree or PCIe bus.
+   This might be called repeatedly as devices are added and removed.
+
+## Device methods
+
+The above approach lets other modules that're oblivious to which drivers exist pass around `struct rgb_led *`s without worrying about their contents.
+
+When these modules want to actually perform an operation, they call the functions in `rgb_led_ops`.
+For example:
+
+```c
+int turn_off_blue(struct rgb_led *led) {
+  u8 r, g;
+  int err;
+
+  err = led->ops->get_colors(led, &r, &g, nullptr);
+  if (!err)
+    return err;
+
+  return led->ops->set_colors(led, r, g, 0);
+}
+```
+
+If `led` is the device object created by our example `acme_led` driver, its `get_colors` function will be `acme_led_get_colors`.
+This function converts the `struct rgb_led` to a `struct acme_led`, then does the appropriate IO.
+
+```c
+static int acme_led_get_colors(struct rgb_led *rgb_led, u8 *out_r, u8 *out_g, u8 *out_b) {
+  struct acme_led *this;
+  u8 r, g, b;
+
+  this = container_of(rgb_led, struct acme_led, rgb_led);
+  r = READ_ONCE(this->regs->r);
+  g = READ_ONCE(this->regs->g);
+  b = READ_ONCE(this->regs->b);
+
+  if (out_r)
+    *out_r = r;
+  if (out_g)
+    *out_g = g;
+  if (out_b)
+    *out_b = b;
+
+  return 0;
+}
+```
+
+The `container_of` macro converts from a pointer to a field of a struct into a pointer to the struct.
+It lets us get the containing `struct acme_led`.
+
+The `READ_ONCE` macro is equivalent to the same macro in Linux.
+It performs a read that the compiler is not permitted to optimize away (hoist out of a loop, constant-fold, etc.).
+This read is atomic, but does not synchronize with any other operation any more than a normal read does (i.e., there's no implicit fence).

--- a/doc/kernel/init.md
+++ b/doc/kernel/init.md
@@ -1,0 +1,12 @@
+# Init Functions
+
+The `init.h` header defines a mechanism to register code to run during boot.
+Blocks of code (initializers) can be registered to run during boot with the `DEFINE_INIT` macro.
+
+This macro takes a priority as well.
+Initializers are run from the lowest priority to highest.
+If two initializers have the same priority, they may be run in any order.
+
+## Priorities
+
+- `INIT_REGISTER_DRIVERS`: The priority level at which drivers should register themselves.

--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+# SPDX-FileCopyrightText: ukoOS Contributors
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/image-milkv-duos-sd/default.nix
+++ b/src/image-milkv-duos-sd/default.nix
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+# SPDX-FileCopyrightText: ukoOS Contributors
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/image-milkv-duos-sd/fsbl-patches/0001-fix-xthead-extension-names.patch
+++ b/src/image-milkv-duos-sd/fsbl-patches/0001-fix-xthead-extension-names.patch
@@ -1,4 +1,4 @@
-SPDX-FileCopyrightText: 2025 ukoOS Contributors
+SPDX-FileCopyrightText: ukoOS Contributors
 
 SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/src/image-milkv-duos-sd/fsbl.nix
+++ b/src/image-milkv-duos-sd/fsbl.nix
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+# SPDX-FileCopyrightText: ukoOS Contributors
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/image-milkv-duos-sd/genimage.cfg
+++ b/src/image-milkv-duos-sd/genimage.cfg
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+# SPDX-FileCopyrightText: ukoOS Contributors
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/image-milkv-duos-sd/opensbi-patches/0002-fix-compiling-with-gcc-15.patch
+++ b/src/image-milkv-duos-sd/opensbi-patches/0002-fix-compiling-with-gcc-15.patch
@@ -1,4 +1,4 @@
-SPDX-FileCopyrightText: 2026 ukoOS Contributors
+SPDX-FileCopyrightText: ukoOS Contributors
 
 SPDX-License-Identifier: BSD-2-Clause
 

--- a/src/image-milkv-duos-sd/opensbi.nix
+++ b/src/image-milkv-duos-sd/opensbi.nix
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+# SPDX-FileCopyrightText: ukoOS Contributors
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/kernel/arch/riscv64/backtrace.c
+++ b/src/kernel/arch/riscv64/backtrace.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/arch/riscv64/bootstub.S
+++ b/src/kernel/arch/riscv64/bootstub.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/arch/riscv64/bootstub.ld
+++ b/src/kernel/arch/riscv64/bootstub.ld
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/arch/riscv64/generate_bootstub.py
+++ b/src/kernel/arch/riscv64/generate_bootstub.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+# SPDX-FileCopyrightText: ukoOS Contributors
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/kernel/arch/riscv64/hart_locals.c
+++ b/src/kernel/arch/riscv64/hart_locals.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/arch/riscv64/include.mak
+++ b/src/kernel/arch/riscv64/include.mak
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+# SPDX-FileCopyrightText: ukoOS Contributors
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/kernel/arch/riscv64/kernel.ld
+++ b/src/kernel/arch/riscv64/kernel.ld
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/arch/riscv64/kernel.ld
+++ b/src/kernel/arch/riscv64/kernel.ld
@@ -56,6 +56,12 @@ SECTIONS
 		*(.data .data.*)
 		PROVIDE(_kernel_end_data = .);
 	} :rw
+	.data.initializers :
+	{
+		PROVIDE(_kernel_start_initializers = .);
+		KEEP(*(.initializers))
+		PROVIDE(_kernel_end_initializers = .);
+	} :rw
 	.bss :
 	{
 		PROVIDE(_kernel_start_bss = .);

--- a/src/kernel/arch/riscv64/paging.c
+++ b/src/kernel/arch/riscv64/paging.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/arch/riscv64/paging.c
+++ b/src/kernel/arch/riscv64/paging.c
@@ -5,6 +5,7 @@
  */
 
 #include <align.h>
+#include <arch/riscv64/constants.h>
 #include <arch/riscv64/insns.h>
 #include <mm/paging.h>
 #include <mm/physical_alloc.h>
@@ -34,10 +35,10 @@ static_assert(alignof(struct pte) == 8);
  * An Sv39 page table.
  */
 struct pgtbl {
-  alignas(4096) struct pte ptes[512];
+  alignas(PAGE_SIZE) struct pte ptes[512];
 };
-static_assert(sizeof(struct pgtbl) == 4096);
-static_assert(alignof(struct pgtbl) == 4096);
+static_assert(sizeof(struct pgtbl) == PAGE_SIZE);
+static_assert(alignof(struct pgtbl) == PAGE_SIZE);
 
 /**
  * The MODE field of the SATP CSR.
@@ -90,7 +91,7 @@ void mm_paging_fence(void) {
 }
 
 static bool mm_paging_walk(uaddr va, paddr *pte, bool alloc) {
-  assert(is_aligned(va, 12), "va={uaddr}", va);
+  assert(is_aligned(va, PAGE_BITS), "va={uaddr}", va);
   assert((uaddr)(((iaddr)va >> 39) + 1) <= 1, "va={uaddr}", va);
   assert(pte);
 
@@ -143,9 +144,9 @@ static bool mm_paging_walk(uaddr va, paddr *pte, bool alloc) {
 }
 
 bool mm_paging_map(uaddr va, paddr pa, enum page_permissions perms) {
-  assert(is_aligned(va, 12), "va={uaddr}", va);
+  assert(is_aligned(va, PAGE_BITS), "va={uaddr}", va);
   assert((uaddr)(((iaddr)va >> 39) + 1) <= 1, "va={uaddr}", va);
-  assert(is_aligned(pa, 12), "pa={paddr}", pa);
+  assert(is_aligned(pa, PAGE_BITS), "pa={paddr}", pa);
 
   paddr pte_addr;
   if (!mm_paging_walk(va, &pte_addr, true))
@@ -192,7 +193,7 @@ bool mm_paging_map(uaddr va, paddr pa, enum page_permissions perms) {
 }
 
 bool mm_paging_unmap(uaddr va, paddr *pa) {
-  assert(is_aligned(va, 12), "va={uaddr}", va);
+  assert(is_aligned(va, PAGE_BITS), "va={uaddr}", va);
   assert((uaddr)(((iaddr)va >> 39) + 1) <= 1, "va={uaddr}", va);
   if (pa)
     *pa = paddr_of_bits(0);
@@ -216,18 +217,18 @@ bool mm_paging_unmap(uaddr va, paddr *pa) {
 
 void *iomem_map(paddr addr, usize size) {
   paddr addr_aligned;
-  addr_aligned = align_down(addr, 12);
-  size = align_up(size + paddr_diff(addr, addr_aligned), 12);
+  addr_aligned = align_down(addr, PAGE_BITS);
+  size = align_up(size + paddr_diff(addr, addr_aligned), PAGE_BITS);
 
   uaddr lo, hi;
   struct vma *vma;
-  vma = vma_alloc(&kernel_virtual_allocator, size >> 12);
+  vma = vma_alloc(&kernel_virtual_allocator, size >> PAGE_BITS);
   if (!vma)
     goto fail;
   vma_bounds(vma, &lo, &hi);
 
   usize i;
-  for (i = 0; i < hi - lo; i += 4096) {
+  for (i = 0; i < hi - lo; i += PAGE_SIZE) {
     uaddr va = lo + i;
     paddr pa = paddr_offset(addr_aligned, i);
     if (!mm_paging_map(va, pa, PGPERM_KRW))
@@ -238,7 +239,7 @@ void *iomem_map(paddr addr, usize size) {
   return (void *)lo;
 
 paging_fail:
-  for (usize j = 0; j < i; j += 4096)
+  for (usize j = 0; j < i; j += PAGE_SIZE)
     assert(mm_paging_unmap(lo + j, nullptr));
 fail:
   return nullptr;
@@ -249,8 +250,8 @@ void iomem_unmap(void *ptr, usize size) {
     return;
 
   void *ptr_aligned;
-  ptr_aligned = align_down(ptr, 12);
-  size = align_up(size + (usize)(ptr - ptr_aligned), 12);
+  ptr_aligned = align_down(ptr, PAGE_BITS);
+  size = align_up(size + (usize)(ptr - ptr_aligned), PAGE_BITS);
 
   uaddr lo, hi;
   struct vma *vma;
@@ -258,7 +259,7 @@ void iomem_unmap(void *ptr, usize size) {
   assert(vma, "No VMA for address {uaddr}", addr_of_ptr(ptr));
   vma_bounds(vma, &lo, &hi);
 
-  for (usize i = 0; i < hi - lo; i += 4096) {
+  for (usize i = 0; i < hi - lo; i += PAGE_SIZE) {
     uaddr va = lo + i;
     assert(mm_paging_unmap(va, nullptr), "Failed to unmap {uaddr}", va);
   }

--- a/src/kernel/arch/riscv64/paging.c
+++ b/src/kernel/arch/riscv64/paging.c
@@ -8,6 +8,7 @@
 #include <arch/riscv64/insns.h>
 #include <mm/paging.h>
 #include <mm/physical_alloc.h>
+#include <mm/virtual_alloc.h>
 #include <panic.h>
 
 /**
@@ -144,7 +145,7 @@ static bool mm_paging_walk(uaddr va, paddr *pte, bool alloc) {
 bool mm_paging_map(uaddr va, paddr pa, enum page_permissions perms) {
   assert(is_aligned(va, 12), "va={uaddr}", va);
   assert((uaddr)(((iaddr)va >> 39) + 1) <= 1, "va={uaddr}", va);
-  assert(is_aligned(pa, 12), "pa={uaddr}", pa);
+  assert(is_aligned(pa, 12), "pa={paddr}", pa);
 
   paddr pte_addr;
   if (!mm_paging_walk(va, &pte_addr, true))
@@ -193,8 +194,8 @@ bool mm_paging_map(uaddr va, paddr pa, enum page_permissions perms) {
 bool mm_paging_unmap(uaddr va, paddr *pa) {
   assert(is_aligned(va, 12), "va={uaddr}", va);
   assert((uaddr)(((iaddr)va >> 39) + 1) <= 1, "va={uaddr}", va);
-  assert(pa);
-  *pa = paddr_of_bits(0);
+  if (pa)
+    *pa = paddr_of_bits(0);
 
   paddr pte_addr;
   if (!mm_paging_walk(va, &pte_addr, false))
@@ -205,9 +206,62 @@ bool mm_paging_unmap(uaddr va, paddr *pa) {
   if (!pte.valid)
     return false;
 
-  pa->ppn = pte.ppn;
+  if (pa)
+    pa->ppn = pte.ppn;
   pte = (struct pte){0};
   copy_to_physical(pte_addr, &pte, sizeof(struct pte));
 
   return true;
+}
+
+void *iomem_map(paddr addr, usize size) {
+  paddr addr_aligned;
+  addr_aligned = align_down(addr, 12);
+  size = align_up(size + paddr_diff(addr, addr_aligned), 12);
+
+  uaddr lo, hi;
+  struct vma *vma;
+  vma = vma_alloc(&kernel_virtual_allocator, size >> 12);
+  if (!vma)
+    goto fail;
+  vma_bounds(vma, &lo, &hi);
+
+  usize i;
+  for (i = 0; i < hi - lo; i += 4096) {
+    uaddr va = lo + i;
+    paddr pa = paddr_offset(addr_aligned, i);
+    if (!mm_paging_map(va, pa, PGPERM_KRW))
+      goto paging_fail;
+  }
+
+  // TODO: Have some provenance to use here.
+  return (void *)lo;
+
+paging_fail:
+  for (usize j = 0; j < i; j += 4096)
+    assert(mm_paging_unmap(lo + j, nullptr));
+fail:
+  return nullptr;
+}
+
+void iomem_unmap(void *ptr, usize size) {
+  if (!ptr)
+    return;
+
+  void *ptr_aligned;
+  ptr_aligned = align_down(ptr, 12);
+  size = align_up(size + (usize)(ptr - ptr_aligned), 12);
+
+  uaddr lo, hi;
+  struct vma *vma;
+  vma = vma_find(&kernel_virtual_allocator, addr_of_ptr(ptr));
+  assert(vma, "No VMA for address {uaddr}", addr_of_ptr(ptr));
+  vma_bounds(vma, &lo, &hi);
+
+  for (usize i = 0; i < hi - lo; i += 4096) {
+    uaddr va = lo + i;
+    assert(mm_paging_unmap(va, nullptr), "Failed to unmap {uaddr}", va);
+  }
+
+  vma_free(vma);
 }

--- a/src/kernel/arch/riscv64/panic.c
+++ b/src/kernel/arch/riscv64/panic.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/arch/riscv64/physical.c
+++ b/src/kernel/arch/riscv64/physical.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/arch/riscv64/random.c
+++ b/src/kernel/arch/riscv64/random.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/arch/riscv64/sbi.c
+++ b/src/kernel/arch/riscv64/sbi.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/arch/riscv64/start.S
+++ b/src/kernel/arch/riscv64/start.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/builtins/bzero.c
+++ b/src/kernel/builtins/bzero.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/builtins/explicit_bzero.c
+++ b/src/kernel/builtins/explicit_bzero.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/builtins/memcmp.c
+++ b/src/kernel/builtins/memcmp.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/builtins/memcpy.c
+++ b/src/kernel/builtins/memcpy.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/builtins/memset.c
+++ b/src/kernel/builtins/memset.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/builtins/strcmp.c
+++ b/src/kernel/builtins/strcmp.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/builtins/strlen.c
+++ b/src/kernel/builtins/strlen.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/crypto/subtle/rfc7539.c
+++ b/src/kernel/crypto/subtle/rfc7539.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/crypto/subtle/rfc7693.c
+++ b/src/kernel/crypto/subtle/rfc7693.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/device.c
+++ b/src/kernel/device.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/device.c
+++ b/src/kernel/device.c
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <device.h>
+#include <init.h>
+
+void device_add(struct device *parent, struct device *child) {
+  assert(parent->name);
+
+  assert(child->name);
+  assert(!child->parent);
+  assert(list_is_empty(&child->parent_children));
+  assert(list_is_empty(&child->children));
+
+  child->parent = parent;
+  list_push(&parent->children, &child->parent_children);
+}
+
+void print_devices(void) {
+  struct device *device = &root_device;
+  usize depth = 1;
+
+  print("devices {{");
+
+  assert(list_is_empty(&device->parent_children));
+  for (;;) {
+    assert(device->name);
+    print("{indent}{cstr} {cstr}", 2 * depth, device->name,
+          list_is_empty(&device->children) ? "" : " {");
+
+    if (!list_is_empty(&device->children)) {
+      // Try to go to our first child.
+      depth++;
+      device =
+          container_of(device->children.next, struct device, parent_children);
+    } else {
+      // Go up the tree until we find a node with a next sibling, or we've
+      // returned to the root.
+      while (device->parent &&
+             device->parent_children.next == &device->parent->children) {
+        device = device->parent;
+        assert(depth > 1);
+        depth--;
+        print("{indent}}}", 2 * depth);
+      }
+
+      // If we're at the root, stop traversing.
+      if (!device->parent) {
+        assert(depth == 1);
+        break;
+      }
+
+      // Otherwise, go to our sibling.
+      device = container_of(device->parent_children.next, struct device,
+                            parent_children);
+    }
+  }
+
+  print("}}");
+}
+
+struct device root_device = {0};
+
+// Despite not being a driver, we initialize the root device here. We know we
+// won't be creating devices yet, so it's a convenient point to do so.
+DEFINE_INIT(INIT_REGISTER_DRIVERS) {
+  root_device = DEVICE_INIT(root_device, "root-device");
+}

--- a/src/kernel/devices/uart.c
+++ b/src/kernel/devices/uart.c
@@ -1,0 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <devices/uart.h>
+
+struct list_head uarts = LIST_INIT(uarts);

--- a/src/kernel/devices/uart.c
+++ b/src/kernel/devices/uart.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/devicetree.c
+++ b/src/kernel/devicetree.c
@@ -598,13 +598,32 @@ bool devicetree_prop_reg(struct devicetree_prop *prop, usize i, paddr *out_addr,
   return true;
 }
 
+static char *devicetree_path(struct devicetree_node *node) {
+  if (!node->parent)
+    return format("/");
+
+  char *out = format("{cstr}", node->name);
+
+  while (node->parent) {
+    node = node->parent;
+    char *next = format("{cstr}/{cstr}", node->name, out);
+    free(out);
+    out = next;
+  }
+
+  return out;
+}
+
 void devicetree_print(struct devicetree_node *node) {
   if (!node) {
     print("nullptr");
     return;
   }
 
-  print("/ {{");
+  char *path = devicetree_path(node);
+  print("{cstr} {{", path);
+  free(path);
+
   usize depth = 2;
   while (depth && node) {
     // Print each property.

--- a/src/kernel/devicetree.c
+++ b/src/kernel/devicetree.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/devicetree.c
+++ b/src/kernel/devicetree.c
@@ -10,6 +10,7 @@
 #include <mm/alloc.h>
 #include <print.h>
 #include <random.h>
+#include <symbolicate.h>
 
 struct fdt_header {
   u32 magic;
@@ -458,6 +459,7 @@ static void devicetree_prop_free(struct devicetree_prop *prop) {
 }
 
 void devicetree_free(struct devicetree_node *node) {
+  assert(!node || !node->parent);
   while (node) {
     // Free every property.
     while (!list_is_empty(&node->props))
@@ -488,6 +490,7 @@ void devicetree_free(struct devicetree_node *node) {
 
 struct devicetree_node *devicetree_child(struct devicetree_node *parent,
                                          const char *name) {
+  assert(parent);
   for (struct list_head *child = parent->children.next;
        child != &parent->children; child = child->next) {
     struct devicetree_node *node =
@@ -500,6 +503,7 @@ struct devicetree_node *devicetree_child(struct devicetree_node *parent,
 
 struct devicetree_prop *devicetree_prop(struct devicetree_node *parent,
                                         const char *name) {
+  assert(parent);
   for (struct list_head *child = parent->props.next; child != &parent->props;
        child = child->next) {
     struct devicetree_prop *prop =
@@ -541,6 +545,12 @@ bool devicetree_address_size_cells(struct devicetree_node *node,
   *out_address_cells = big_to_native(*out_address_cells);
   *out_size_cells = big_to_native(*out_size_cells);
   return true;
+}
+
+bool devicetree_reg(struct devicetree_node *node, usize i, paddr *out_addr,
+                    usize *out_size) {
+  return devicetree_prop_reg(devicetree_prop(node, "reg"), i, out_addr,
+                             out_size);
 }
 
 bool devicetree_prop_reg(struct devicetree_prop *prop, usize i, paddr *out_addr,
@@ -677,4 +687,123 @@ void devicetree_add_entropy(struct devicetree_node *root) {
   entropy_pool_mix(rng_seed->value, rng_seed->value_len);
   entropy_pool_credit(8 * rng_seed->value_len);
   devicetree_prop_free(rng_seed);
+}
+
+struct devicetree_handler {
+  const char *compatible;
+  usize compatible_len;
+  struct device *(*handler)(struct devicetree_node *node);
+};
+
+/**
+ * A vector of handlers.
+ *
+ * TODO: Replace this with a hashtable of vectors or similar.
+ */
+static struct devicetree_handler *handlers = nullptr;
+static usize handlers_cap = 0, handlers_len = 0;
+
+static void devicetree_enumerate_one(struct devicetree_node *node) {
+  assert(node);
+
+  struct devicetree_prop *prop = devicetree_prop(node, "compatible");
+  if (!prop)
+    return;
+
+  const u8 *str = prop->value;
+  usize len = prop->value_len;
+
+  while (len) {
+    usize item_len = strlen((const char *)str);
+
+    for (usize i = 0; i < handlers_len; i++) {
+      if (handlers[i].compatible_len != item_len)
+        continue;
+      if (memcmp(handlers[i].compatible, str, item_len) != 0)
+        continue;
+
+      struct device *device = handlers[i].handler(node);
+      if (device) {
+        device_add(&root_device, device);
+        return;
+      } else {
+        struct symbolicated symbolicated;
+        if (symbolicate(&symbolicated, addr_of_ptr(handlers[i].handler))) {
+          print("Devicetree handler <{cstr}+{usize}> failed to initialize a "
+                "device",
+                symbolicated.name, symbolicated.offset);
+        } else {
+          print("Devicetree handler <{uaddr}> failed to initialize a device",
+                addr_of_ptr(handlers[i].handler));
+        }
+      }
+    }
+
+    str += item_len + 1;
+    len -= item_len + 1;
+  }
+}
+
+void devicetree_enumerate(struct devicetree_node *root) {
+  assert(root);
+
+  struct devicetree_node *node = root;
+  for (;;) {
+    // Traverse down and to the left as far as we can.
+    if (!list_is_empty(&node->children)) {
+      node = container_of(node->children.next, struct devicetree_node,
+                          parent_children_head);
+      continue;
+    }
+
+    // At this point, we're at a leaf.
+    assert(list_is_empty(&node->children));
+
+    // While we're the right-most child, go up. This counts as leaving the node,
+    // so check the node for a `compatible` prop before doing so.
+    while (node->parent &&
+           node->parent_children_head.next == &node->parent->children) {
+      devicetree_enumerate_one(node);
+      node = node->parent;
+    }
+
+    // If we left the root, we're done.
+    if (!node->parent)
+      break;
+
+    // We now have a right sibling, which we can go to. This count as leaving
+    // the node, so we'll check the node for a `compatible` prop. Next
+    // iteration, we'll descend.
+    assert(node->parent_children_head.next != &node->parent->children);
+    devicetree_enumerate_one(node);
+    node = container_of(node->parent_children_head.next, struct devicetree_node,
+                        parent_children_head);
+  }
+}
+
+void devicetree_register(
+    const char *compatible,
+    struct device *(*handler)(struct devicetree_node *node)) {
+  assert(compatible && handler);
+
+  if (!handlers) {
+    assert(!handlers_len);
+    handlers_cap = 16;
+    handlers = alloc(sizeof(struct devicetree_handler) * handlers_cap);
+    assert(handlers, "Failed to allocate handlers vector");
+  }
+
+  if (handlers_cap == handlers_len) {
+    handlers_cap *= 2;
+    struct devicetree_handler *new_handlers =
+        realloc(handlers, sizeof(struct devicetree_handler) * handlers_cap);
+    assert(new_handlers, "Failed to reallocate handlers vector");
+    handlers = new_handlers;
+  }
+
+  handlers[handlers_len++] = (struct devicetree_handler){
+      .compatible = compatible,
+      .compatible_len = strlen(compatible),
+      .handler = handler,
+  };
 }

--- a/src/kernel/drivers/include.mak
+++ b/src/kernel/drivers/include.mak
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+# SPDX-FileCopyrightText: ukoOS Contributors
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/kernel/drivers/include.mak
+++ b/src/kernel/drivers/include.mak
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+kernel-objs-c += drivers/ns16550a

--- a/src/kernel/drivers/ns16550a.c
+++ b/src/kernel/drivers/ns16550a.c
@@ -8,6 +8,7 @@
 #include <devicetree.h>
 #include <mm/paging.h>
 #include <physical.h>
+#include <volatile.h>
 
 /**
  * The bits of the Interrupt Enable Register.
@@ -75,6 +76,22 @@ struct ns16550a_iir {
 };
 
 /**
+ * The bits of the Line Status Register.
+ */
+struct ns16550a_lsr {
+  /**
+   */
+  bool data_ready : 1;
+  bool overrun_error : 1;
+  bool parity_error : 1;
+  bool framing_error : 1;
+  bool break_interrupt : 1;
+  bool empty_transmitter_holding_register : 1;
+  bool empty_data_holding_registers : 1;
+  bool error_in_received_fifo : 1;
+};
+
+/**
  * The UART's registers.
  */
 struct ns16550a_regs {
@@ -137,7 +154,7 @@ struct ns16550a_regs {
   /**
    * The Line Status Register.
    */
-  u8 lsr;
+  struct ns16550a_lsr lsr;
 
   /**
    * The Modem Status Register.
@@ -158,7 +175,14 @@ struct ns16550a {
   struct ns16550a_regs *regs;
 };
 
-static void ns16550a_write_byte(struct uart *uart, u8 byte) { TODO(); }
+static void ns16550a_write_byte(struct uart *uart, u8 byte) {
+  struct ns16550a *ns16550a = container_of(uart, struct ns16550a, uart);
+
+  // TODO: This should not busy-wait, this should be interrupt-triggered.
+  while (!READ_ONCE(&ns16550a->regs->lsr).empty_transmitter_holding_register)
+    ;
+  WRITE_ONCE(&ns16550a->regs->thr, byte);
+}
 
 static const struct uart_ops ns16550a_uart_ops = {
     .write_byte = ns16550a_write_byte,

--- a/src/kernel/drivers/ns16550a.c
+++ b/src/kernel/drivers/ns16550a.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/drivers/ns16550a.c
+++ b/src/kernel/drivers/ns16550a.c
@@ -1,0 +1,209 @@
+/*
+ * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <devices/uart.h>
+#include <devicetree.h>
+#include <mm/paging.h>
+#include <physical.h>
+
+/**
+ * The bits of the Interrupt Enable Register.
+ */
+struct ns16550a_ier {
+  /**
+   * Enable Receiver Buffer Full Interrupt.
+   */
+  bool erbfi : 1;
+
+  /**
+   * Enable Transmitter Buffer Empty Interrupt.
+   */
+  bool etbei : 1;
+
+  /**
+   * Enable (Receiver) Line Status Interrupt.
+   */
+  bool elsi : 1;
+
+  /**
+   * Enable Modem Status Interrupt.
+   */
+  bool edssi : 1;
+
+  /**
+   * Reserved, should be zero.
+   *
+   * Wikipedia suggests that the 16750 uses some of these bits.
+   */
+  u8 rsvd : 4;
+};
+
+/**
+ * The bits of the Interrupt Identification Register.
+ */
+struct ns16550a_iir {
+  /**
+   * A bit that becomes unset when an interrupt is pending.
+   */
+  bool interrupt_pending : 1;
+
+  /**
+   * The index of the bit in `ns16550a_ier` corresponding to the pending
+   * interrupt.
+   */
+  u8 interrupt_id : 3;
+
+  /**
+   * Reserved, should be zero.
+   *
+   * Wikipedia suggests that the 16750 uses some of these bits.
+   */
+  u8 rsvd : 2;
+
+  /**
+   * A flag for whether the FIFOs are currently functioning.
+   */
+  bool fifo_working : 1;
+
+  /**
+   * A flag for whether the FIFOs are enabled.
+   */
+  bool fifo_enabled : 1;
+};
+
+/**
+ * The UART's registers.
+ */
+struct ns16550a_regs {
+  union {
+    /**
+     * The Receiver Buffer Register. Read-only. Only valid when DLAB is unset.
+     */
+    u8 rbr;
+
+    /**
+     * The Transmitter Holding Register. Write-only. Only valid when DLAB is
+     * unset.
+     */
+    u8 thr;
+
+    /**
+     * The Divisor Latch Low byte. Only valid when DLAB is set.
+     */
+    u8 dll;
+  };
+
+  /**
+   * When DLAB is unset, this is the Interrupt Enable Register. When DLAB is
+   * set, this is.
+   */
+  union {
+    /**
+     * The Interrupt Enable Register. Only valid when DLAB is unset.
+     */
+    struct ns16550a_ier ier;
+
+    /**
+     * The Divisor Latch High byte. Only valid when DLAB is set.
+     */
+    u8 dlh;
+  };
+
+  union {
+    /**
+     * The Interrupt Identification Register. Read-only.
+     */
+    struct ns16550a_iir iir;
+
+    /**
+     * The FIFO Control Register. Write-only.
+     */
+    u8 fcr;
+  };
+
+  /**
+   * The Line Control Register.
+   */
+  u8 lcr;
+
+  /**
+   * The Modem Control Register.
+   */
+  u8 mcr;
+
+  /**
+   * The Line Status Register.
+   */
+  u8 lsr;
+
+  /**
+   * The Modem Status Register.
+   */
+  u8 msr;
+
+  /**
+   * The Scratch Register.
+   */
+  u8 sr;
+};
+
+static_assert(sizeof(struct ns16550a_regs) == 8);
+
+struct ns16550a {
+  struct device device;
+  struct uart uart;
+  struct ns16550a_regs *regs;
+};
+
+static void ns16550a_write_byte(struct uart *uart, u8 byte) { TODO(); }
+
+static const struct uart_ops ns16550a_uart_ops = {
+    .write_byte = ns16550a_write_byte,
+};
+
+static struct device *ns16550a_enumerate_dt(struct devicetree_node *node) {
+  struct ns16550a *device = nullptr;
+  paddr reg_addr;
+  usize reg_size;
+
+  if (!devicetree_reg(node, 0, &reg_addr, &reg_size))
+    goto fail;
+  if (reg_size < sizeof(struct ns16550a_regs))
+    goto fail;
+
+  device = alloc(sizeof(struct ns16550a));
+  if (!device)
+    goto fail;
+
+  *device = (struct ns16550a){
+      .device = DEVICE_INIT(device->device, "ns16550a@{paddr}", reg_addr),
+      .uart =
+          {
+              .list = LIST_INIT(device->uart.list),
+              .ops = &ns16550a_uart_ops,
+              .device = &device->device,
+          },
+      .regs = iomem_map(reg_addr, reg_size),
+  };
+  if (!device->device.name || !device->regs)
+    goto fail;
+
+  list_push(&uarts, &device->uart.list);
+
+  return &device->device;
+
+fail:
+  if (device) {
+    free(device->device.name);
+    iomem_unmap(device->regs, reg_size);
+  }
+  free(device);
+  return nullptr;
+}
+
+DEFINE_INIT(INIT_REGISTER_DRIVERS) {
+  devicetree_register("ns16550a", ns16550a_enumerate_dt);
+}

--- a/src/kernel/include.mak
+++ b/src/kernel/include.mak
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+# SPDX-FileCopyrightText: ukoOS Contributors
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/kernel/include.mak
+++ b/src/kernel/include.mak
@@ -49,4 +49,8 @@ kernel-objs-c += random
 kernel-objs-c += selftest
 kernel-objs-c += swar_test
 kernel-objs-c += symbolicate
+include $(srcdir)/src/kernel/drivers/include.mak
+
+# The architecture-specific file needs to be last, since it calls
+# compute_component_variables for the kernel.
 include $(srcdir)/src/kernel/arch/$(arch)/include.mak

--- a/src/kernel/include.mak
+++ b/src/kernel/include.mak
@@ -31,6 +31,7 @@ kernel-objs-c += builtins/strlen
 kernel-objs-c += crypto/subtle/rfc7539
 kernel-objs-c += crypto/subtle/rfc7693
 kernel-objs-c += device
+kernel-objs-c += devices/uart
 kernel-objs-c += devicetree
 kernel-objs-c += init
 kernel-objs-c += main

--- a/src/kernel/include.mak
+++ b/src/kernel/include.mak
@@ -30,6 +30,7 @@ kernel-objs-c += builtins/strcmp
 kernel-objs-c += builtins/strlen
 kernel-objs-c += crypto/subtle/rfc7539
 kernel-objs-c += crypto/subtle/rfc7693
+kernel-objs-c += device
 kernel-objs-c += devicetree
 kernel-objs-c += init
 kernel-objs-c += main

--- a/src/kernel/include.mak
+++ b/src/kernel/include.mak
@@ -31,6 +31,7 @@ kernel-objs-c += builtins/strlen
 kernel-objs-c += crypto/subtle/rfc7539
 kernel-objs-c += crypto/subtle/rfc7693
 kernel-objs-c += devicetree
+kernel-objs-c += init
 kernel-objs-c += main
 kernel-objs-c += mm/alloc
 kernel-objs-c += mm/alloc/block

--- a/src/kernel/include/align.h
+++ b/src/kernel/include/align.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/align.h
+++ b/src/kernel/include/align.h
@@ -22,15 +22,30 @@ static inline bool _is_aligned_uaddr(uaddr addr, usize bits) {
   return _align_down_uaddr(addr, bits) == addr;
 }
 
+static inline void *_align_down_ptr(void *ptr, usize bits) {
+  return ptr_with_addr(ptr, _align_down_uaddr(addr_of_ptr(ptr), bits));
+}
+
+static inline void *_align_up_ptr(void *ptr, usize bits) {
+  return ptr_with_addr(ptr, _align_up_uaddr(addr_of_ptr(ptr), bits));
+}
+
 static inline bool _is_aligned_ptr(const void *ptr, usize bits) {
   return _is_aligned_uaddr(addr_of_ptr(ptr), bits);
 }
 
 #define align_down(ADDR, BITS)                                                 \
-  (_Generic(ADDR, paddr: _align_down_paddr, uaddr: _align_down_uaddr)(ADDR,    \
-                                                                      BITS))
+  (_Generic(ADDR,                                                              \
+       void *: _align_down_ptr,                                                \
+       paddr: _align_down_paddr,                                               \
+       uaddr: _align_down_uaddr)(ADDR, BITS))
+
 #define align_up(ADDR, BITS)                                                   \
-  (_Generic(ADDR, paddr: _align_up_paddr, uaddr: _align_up_uaddr)(ADDR, BITS))
+  (_Generic(ADDR,                                                              \
+       void *: _align_up_ptr,                                                  \
+       paddr: _align_up_paddr,                                                 \
+       uaddr: _align_up_uaddr)(ADDR, BITS))
+
 #define is_aligned(ADDR, BITS)                                                 \
   ({                                                                           \
     const auto __is_aligned_ADDR = (ADDR);                                     \

--- a/src/kernel/include/arch/riscv64/constants.h
+++ b/src/kernel/include/arch/riscv64/constants.h
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: ukoOS Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef UKO_OS_KERNEL__ARCH_RISCV64_CONSTANTS_H
+#define UKO_OS_KERNEL__ARCH_RISCV64_CONSTANTS_H 1
+
+/**
+ * RISC-V-specific constants.
+ */
+
+#include <types.h>
+
+constexpr usize PAGE_BITS = 12;
+
+// TODO: Should this formula live in a different header?
+constexpr usize PAGE_SIZE = 1 << PAGE_BITS;
+
+#endif // UKO_OS_KERNEL__ARCH_RISCV64_CONSTANTS_H

--- a/src/kernel/include/arch/riscv64/insns.h
+++ b/src/kernel/include/arch/riscv64/insns.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/arch/riscv64/sbi.h
+++ b/src/kernel/include/arch/riscv64/sbi.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/arch/riscv64/volatile.h
+++ b/src/kernel/include/arch/riscv64/volatile.h
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: ukoOS Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef UKO_OS_KERNEL__ARCH_RISCV64_VOLATILE_H
+#define UKO_OS_KERNEL__ARCH_RISCV64_VOLATILE_H 1
+
+/**
+ * TODO:
+ *
+ * - GCC emits extra `andi a0, a0, 0xff`s on each of the _read_once_* functions.
+ *   I assume this is because we don't have a way to promise to the compiler
+ *   that we zeroed the top bits. We should fix this.
+ */
+
+#include <types.h>
+
+static inline u8 _read_once_u8(u8 *ptr) {
+  u8 out;
+  __asm__("lbu %0, %1" : "=r"(out) : "m"(*ptr) : "memory");
+  return out;
+}
+
+static inline u16 _read_once_u16(u16 *ptr) {
+  u16 out;
+  __asm__("lhu %0, %1" : "=r"(out) : "m"(*ptr) : "memory");
+  return out;
+}
+
+static inline u32 _read_once_u32(u32 *ptr) {
+  u32 out;
+  __asm__("lwu %0, %1" : "=r"(out) : "m"(*ptr) : "memory");
+  return out;
+}
+
+static inline u64 _read_once_u64(u64 *ptr) {
+  u64 out;
+  __asm__("ld %0, %1" : "=r"(out) : "m"(*ptr) : "memory");
+  return out;
+}
+
+static inline void _write_once_u8(u8 *ptr, u8 val) {
+  __asm__("sb %0, %1" : : "r"(val), "m"(*ptr) : "memory");
+}
+
+static inline void _write_once_u16(u16 *ptr, u16 val) {
+  __asm__("sh %0, %1" : : "r"(val), "m"(*ptr) : "memory");
+}
+
+static inline void _write_once_u32(u32 *ptr, u32 val) {
+  __asm__("sw %0, %1" : : "r"(val), "m"(*ptr) : "memory");
+}
+
+static inline void _write_once_u64(u64 *ptr, u64 val) {
+  __asm__("sd %0, %1" : : "r"(val), "m"(*ptr) : "memory");
+}
+
+#endif // UKO_OS_KERNEL__ARCH_RISCV64_VOLATILE_H

--- a/src/kernel/include/compiler.h
+++ b/src/kernel/include/compiler.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/container.h
+++ b/src/kernel/include/container.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/crypto/subtle/fnv1a.h
+++ b/src/kernel/include/crypto/subtle/fnv1a.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/crypto/subtle/random_internals.h
+++ b/src/kernel/include/crypto/subtle/random_internals.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/crypto/subtle/rfc7539.h
+++ b/src/kernel/include/crypto/subtle/rfc7539.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/crypto/subtle/rfc7693.h
+++ b/src/kernel/include/crypto/subtle/rfc7693.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/device.h
+++ b/src/kernel/include/device.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/device.h
+++ b/src/kernel/include/device.h
@@ -69,10 +69,10 @@ extern struct device root_device;
 /**
  * Registers a device in the tree of devices and with its device class.
  *
- * - `name` must be filled out.
- * - `parent` and `device_class` must be `nullptr`.
- * - `parent_children`, `children`, and `device_class_members` must be
- *   self-linked.
+ * - `child->name` must be filled out.
+ * - `child->parent` and `child->device_class` must be `nullptr`.
+ * - `child->parent_children`, `child->children`, and
+ *   `child->device_class_members` must be self-linked.
  */
 [[gnu::nonnull(1, 2)]]
 void device_add(struct device *parent, struct device *child);

--- a/src/kernel/include/device.h
+++ b/src/kernel/include/device.h
@@ -1,0 +1,85 @@
+/*
+ * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef UKO_OS_KERNEL__DEVICE_H
+#define UKO_OS_KERNEL__DEVICE_H 1
+
+#include <init.h>
+#include <list.h>
+#include <print.h>
+
+/**
+ * A node in the tree of devices attached to the system.
+ */
+struct device {
+  /**
+   * The name of the device. This must be unique amongst its siblings.
+   *
+   * This should be `alloc`-allocated.
+   */
+  char *name;
+
+  /**
+   * The parent of the node. `nullptr` for the root node.
+   */
+  struct device *parent;
+
+  /**
+   * The `list_head` for this device's entry in `parent->children`.
+   */
+  struct list_head parent_children;
+
+  /**
+   * The children of the node.
+   */
+  struct list_head children;
+};
+
+/**
+ * Returns an initializer for the `struct device` `DEVICE`.
+ *
+ * ### Example
+ *
+ * ```c
+ * struct my_device {
+ *   // ...
+ *   struct device device;
+ *   // ...
+ * };
+ *
+ * struct my_device *my_device = alloc(sizeof(*my_device));
+ * my_device->device = DEVICE_INIT(my_device->device, "example");
+ * ```
+ */
+#define DEVICE_INIT(DEVICE, NAME_FORMAT, ...)                                  \
+  (struct device) {                                                            \
+    .name = format(NAME_FORMAT __VA_OPT__(, ) __VA_ARGS__), .parent = nullptr, \
+    .parent_children = LIST_INIT((DEVICE).parent_children),                    \
+    .children = LIST_INIT((DEVICE).children),                                  \
+  }
+
+/**
+ * The root of the tree of devices.
+ */
+extern struct device root_device;
+
+/**
+ * Registers a device in the tree of devices and with its device class.
+ *
+ * - `name` must be filled out.
+ * - `parent` and `device_class` must be `nullptr`.
+ * - `parent_children`, `children`, and `device_class_members` must be
+ *   self-linked.
+ */
+[[gnu::nonnull(1, 2)]]
+void device_add(struct device *parent, struct device *child);
+
+/**
+ * Prints the tree of devices.
+ */
+void print_devices(void);
+
+#endif // UKO_OS_KERNEL__DEVICE_H

--- a/src/kernel/include/devices/uart.h
+++ b/src/kernel/include/devices/uart.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/devices/uart.h
+++ b/src/kernel/include/devices/uart.h
@@ -24,7 +24,7 @@ struct uart {
   const struct uart_ops *ops;
 
   /**
-   * A pointer to the _same_ device.
+   * A pointer to the `struct device` for this UART.
    */
   struct device *device;
 };

--- a/src/kernel/include/devices/uart.h
+++ b/src/kernel/include/devices/uart.h
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef UKO_OS_KERNEL__DEVICES_UART_H
+#define UKO_OS_KERNEL__DEVICES_UART_H 1
+
+#include <device.h>
+
+/**
+ * A UART device.
+ */
+struct uart {
+  /**
+   * The list head used to link the uart into the `uarts` list.
+   */
+  struct list_head list;
+
+  /**
+   * The vtable.
+   */
+  const struct uart_ops *ops;
+
+  /**
+   * A pointer to the _same_ device.
+   */
+  struct device *device;
+};
+
+/**
+ * The vtable for a UART.
+ */
+struct uart_ops {
+  /**
+   * Writes a single byte to the UART.
+   *
+   * TODO: This should be replaced by a more DMA-friendly API.
+   */
+  void (*write_byte)(struct uart *this, u8 byte);
+};
+
+/**
+ * The list of all UART devices.
+ */
+extern struct list_head uarts;
+
+#endif // UKO_OS_KERNEL__DEVICES_UART_H

--- a/src/kernel/include/devicetree.h
+++ b/src/kernel/include/devicetree.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/devicetree.h
+++ b/src/kernel/include/devicetree.h
@@ -7,7 +7,7 @@
 #ifndef UKO_OS_KERNEL__DEVICETREE_H
 #define UKO_OS_KERNEL__DEVICETREE_H 1
 
-#include <list.h>
+#include <device.h>
 
 /**
  * A property in the Devicetree.
@@ -103,6 +103,13 @@ bool devicetree_address_size_cells(struct devicetree_node *node,
                                    u32 *out_address_cells, u32 *out_size_cells);
 
 /**
+ * Retrieves the `i`th address and size pair from the `reg` property of a node.
+ * Returns whether this succeeded.
+ */
+bool devicetree_reg(struct devicetree_node *node, usize i, paddr *out_addr,
+                    usize *out_size);
+
+/**
  * Retrieves the `i`th address and size pair from a property. This is useful
  * for properties like `reg`. Returns whether this succeeded.
  */
@@ -119,5 +126,20 @@ void devicetree_print(struct devicetree_node *root);
  * from the Devicetree.
  */
 void devicetree_add_entropy(struct devicetree_node *root);
+
+/**
+ * Walks the Devicetree. On each node with a `compatible` prop, all the handlers
+ * registered with `devicetree_register` that could apply are called until one
+ * returns non-`nullptr`.
+ */
+void devicetree_enumerate(struct devicetree_node *root);
+
+/**
+ * Adds a handler for devices with the given value for the `compatible` prop,
+ * for use by `devicetree_enumerate`.
+ */
+void devicetree_register(
+    const char *compatible,
+    struct device *(*handler)(struct devicetree_node *node));
 
 #endif // UKO_OS_KERNEL__DEVICETREE_H

--- a/src/kernel/include/endian.h
+++ b/src/kernel/include/endian.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/hart_locals.h
+++ b/src/kernel/include/hart_locals.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/init.h
+++ b/src/kernel/include/init.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/init.h
+++ b/src/kernel/include/init.h
@@ -10,14 +10,49 @@
 #include <macro_utils.h>
 #include <types.h>
 
+/**
+ * The pre-defined priority levels.
+ */
+enum initializer_priority : i32 {
+  /**
+   * The priority level at which drivers should register themselves.
+   */
+  INIT_REGISTER_DRIVERS = 10,
+};
+
+/**
+ * An initializer function.
+ */
 struct initializer {
+  /**
+   * The actual function to run.
+   */
   void (*func)(void);
+
+  /**
+   * The path to the file the initializer is defined in.
+   */
   const char *file;
+
+  /**
+   * The line the initializer is defined on.
+   */
   u32 line;
-  i32 priority;
+
+  /**
+   * The priority of the initializer.
+   */
+  enum initializer_priority priority;
 };
 
 #define _DEFINE_INIT(PRIORITY, N)                                              \
+  static_assert(__builtin_classify_type(typeof((PRIORITY))) ==                 \
+                    __builtin_classify_type(enum initializer_priority),        \
+                "PRIORITY must be an enum initializer_priority");              \
+  static_assert(                                                               \
+      _Generic((PRIORITY), enum initializer_priority: true, default: false),   \
+      "PRIORITY must be an enum initializer_priority");                        \
+                                                                               \
   static void __PASTE(__init_func_, N)(void);                                  \
   [[gnu::section(".initializers,\"wa\",@progbits#"), gnu::used]]               \
   static struct initializer __PASTE(__initializer_, N)[1] = {{                 \
@@ -29,7 +64,7 @@ struct initializer {
   static void __PASTE(__init_func_, N)(void)
 
 /**
- * Defines an initializer.
+ * Defines an initializer. `PRIORITY` should be an `enum initializer_priority`.
  */
 #define DEFINE_INIT(PRIORITY) _DEFINE_INIT(PRIORITY, __COUNTER__)
 

--- a/src/kernel/include/list.h
+++ b/src/kernel/include/list.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/list.h
+++ b/src/kernel/include/list.h
@@ -65,8 +65,8 @@ struct list_head {
  * void init_parent(struct parent *p) { p->children = LIST_INIT(p->children); }
  * ```
  */
-#define LIST_INIT(name)                                                        \
-  (struct list_head) { .prev = &(name), .next = &(name) }
+#define LIST_INIT(LIST)                                                        \
+  (struct list_head) { .prev = &(LIST), .next = &(LIST) }
 
 /**
  * Returns whether `list` is empty.

--- a/src/kernel/include/macro_utils.h
+++ b/src/kernel/include/macro_utils.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/minmax.h
+++ b/src/kernel/include/minmax.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/mm/alloc.h
+++ b/src/kernel/include/mm/alloc.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/mm/paging.h
+++ b/src/kernel/include/mm/paging.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/mm/paging.h
+++ b/src/kernel/include/mm/paging.h
@@ -74,4 +74,18 @@ bool mm_paging_map(uaddr va, paddr pa, enum page_permissions perms);
  */
 bool mm_paging_unmap(uaddr va, paddr *pa);
 
+/**
+ * Maps a region of memory for memory-mapped IO. This may involve special flags
+ * or other setup to prevent accesses from being cached.
+ *
+ * Returns a pointer to the virtual address for the region. Returns `nullptr` on
+ * error.
+ */
+void *iomem_map(paddr addr, usize size);
+
+/**
+ * Unmaps memory mapped with `iomem_map`.
+ */
+void iomem_unmap(void *ptr, usize size);
+
 #endif // UKO_OS_KERNEL__MM_PAGING_H

--- a/src/kernel/include/mm/physical_alloc.h
+++ b/src/kernel/include/mm/physical_alloc.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/mm/virtual_alloc.h
+++ b/src/kernel/include/mm/virtual_alloc.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/panic.h
+++ b/src/kernel/include/panic.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/physical.h
+++ b/src/kernel/include/physical.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/print.h
+++ b/src/kernel/include/print.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/random.h
+++ b/src/kernel/include/random.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/selftest.h
+++ b/src/kernel/include/selftest.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/swar.h
+++ b/src/kernel/include/swar.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/symbolicate.h
+++ b/src/kernel/include/symbolicate.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/types.h
+++ b/src/kernel/include/types.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/include/volatile.h
+++ b/src/kernel/include/volatile.h
@@ -1,0 +1,99 @@
+/*
+ * SPDX-FileCopyrightText: ukoOS Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef UKO_OS_KERNEL__VOLATILE_H
+#define UKO_OS_KERNEL__VOLATILE_H 1
+
+/**
+ * Functions for performing "volatile-like" accesses. These do _not_ impose
+ * ordering constraints (unlike actual atomics), _including with respect to each
+ * other_ (making them weaker than relaxed atomics), but do execute atomically.
+ */
+
+// TODO: Figure how to #include <arch/$arch/volatile.h> instead of hard-coding
+// riscv64.
+#include <arch/riscv64/volatile.h>
+
+#define READ_ONCE(PTR)                                                         \
+  ({                                                                           \
+    auto READ_ONCE__ptr = (PTR);                                               \
+    typeof(*READ_ONCE__ptr) READ_ONCE__value;                                  \
+    constexpr usize READ_ONCE__size = sizeof(READ_ONCE__value);                \
+    static_assert(READ_ONCE__size == 1 || READ_ONCE__size == 2 ||              \
+                      READ_ONCE__size == 4 || READ_ONCE__size == 8,            \
+                  "READ_ONCE only supports {1,2,4,8}-byte types");             \
+    switch (READ_ONCE__size) {                                                 \
+    case sizeof(u8): {                                                         \
+      u8 READ_ONCE__buf = _read_once_u8((u8 *)READ_ONCE__ptr);                 \
+      memcpy(&READ_ONCE__value, &READ_ONCE__buf, READ_ONCE__size);             \
+      break;                                                                   \
+    }                                                                          \
+    case sizeof(u16): {                                                        \
+      u16 READ_ONCE__buf = _read_once_u16((u16 *)READ_ONCE__ptr);              \
+      memcpy(&READ_ONCE__value, &READ_ONCE__buf, READ_ONCE__size);             \
+      break;                                                                   \
+    }                                                                          \
+    case sizeof(u32): {                                                        \
+      u32 READ_ONCE__buf = _read_once_u32((u32 *)READ_ONCE__ptr);              \
+      memcpy(&READ_ONCE__value, &READ_ONCE__buf, READ_ONCE__size);             \
+      break;                                                                   \
+    }                                                                          \
+    case sizeof(u64): {                                                        \
+      u64 READ_ONCE__buf = _read_once_u64((u64 *)READ_ONCE__ptr);              \
+      memcpy(&READ_ONCE__value, &READ_ONCE__buf, READ_ONCE__size);             \
+      break;                                                                   \
+    }                                                                          \
+    default: {                                                                 \
+      bzero(&READ_ONCE__value, READ_ONCE__size);                               \
+      break;                                                                   \
+    }                                                                          \
+    }                                                                          \
+    READ_ONCE__value;                                                          \
+  })
+#define WRITE_ONCE(PTR, VAL)                                                   \
+  do {                                                                         \
+    auto WRITE_ONCE__ptr = (PTR);                                              \
+    auto WRITE_ONCE__value = (VAL);                                            \
+    static_assert(                                                             \
+        __builtin_types_compatible_p(typeof(*WRITE_ONCE__ptr),                 \
+                                     typeof(WRITE_ONCE__value)),               \
+        "The type of the pointer and value to WRITE_ONCE must match");         \
+    constexpr usize WRITE_ONCE__size = sizeof(WRITE_ONCE__value);              \
+    static_assert(WRITE_ONCE__size == 1 || WRITE_ONCE__size == 2 ||            \
+                      WRITE_ONCE__size == 4 || WRITE_ONCE__size == 8,          \
+                  "WRITE_ONCE only supports {1,2,4,8}-byte types");            \
+    switch (WRITE_ONCE__size) {                                                \
+    case sizeof(u8): {                                                         \
+      u8 WRITE_ONCE__buf;                                                      \
+      memcpy(&WRITE_ONCE__buf, &WRITE_ONCE__value, WRITE_ONCE__size);          \
+      _write_once_u8((u8 *)WRITE_ONCE__ptr, WRITE_ONCE__buf);                  \
+      break;                                                                   \
+    }                                                                          \
+    case sizeof(u16): {                                                        \
+      u16 WRITE_ONCE__buf;                                                     \
+      memcpy(&WRITE_ONCE__buf, &WRITE_ONCE__value, WRITE_ONCE__size);          \
+      _write_once_u16((u16 *)WRITE_ONCE__ptr, WRITE_ONCE__buf);                \
+      break;                                                                   \
+    }                                                                          \
+    case sizeof(u32): {                                                        \
+      u32 WRITE_ONCE__buf;                                                     \
+      memcpy(&WRITE_ONCE__buf, &WRITE_ONCE__value, WRITE_ONCE__size);          \
+      _write_once_u32((u32 *)WRITE_ONCE__ptr, WRITE_ONCE__buf);                \
+      break;                                                                   \
+    }                                                                          \
+    case sizeof(u64): {                                                        \
+      u64 WRITE_ONCE__buf;                                                     \
+      memcpy(&WRITE_ONCE__buf, &WRITE_ONCE__value, WRITE_ONCE__size);          \
+      _write_once_u64((u64 *)WRITE_ONCE__ptr, WRITE_ONCE__buf);                \
+      break;                                                                   \
+    }                                                                          \
+    default: {                                                                 \
+      break;                                                                   \
+    }                                                                          \
+    }                                                                          \
+  } while (0)
+
+#endif // UKO_OS_KERNEL__ARCH_RISCV64_VOLATILE_H

--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <init.h>
+
+extern struct initializer _kernel_start_initializers[],
+    _kernel_end_initializers[];
+
+static void sort_initializers(struct initializer *ptr, usize len) {
+  while (len) {
+    i32 min_priority = ptr->priority;
+    usize min_index = 0;
+
+    for (usize i = 0; i < len; i++) {
+      if (ptr[i].priority < min_priority) {
+        min_priority = ptr[i].priority;
+        min_index = i;
+      }
+    }
+
+    if (min_index != 0) {
+      struct initializer tmp = *ptr;
+      *ptr = ptr[min_index];
+      ptr[min_index] = tmp;
+    }
+
+    ptr++;
+    len--;
+  }
+}
+
+void run_initializers(void) {
+  const usize initializers_len =
+      (usize)(&_kernel_end_initializers[0] - &_kernel_start_initializers[0]);
+  sort_initializers(_kernel_start_initializers, initializers_len);
+  for (usize i = 0; i < initializers_len; i++) {
+    struct initializer initializer = _kernel_start_initializers[i];
+    initializer.func();
+  }
+}

--- a/src/kernel/main.c
+++ b/src/kernel/main.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/main.c
+++ b/src/kernel/main.c
@@ -49,6 +49,9 @@ void main(u64 hart_id, paddr devicetree_start, paddr kernel_start,
   // Run initializers, which include e.g. registering drivers.
   run_initializers();
 
+  // Enumerate devices in the devicetree.
+  devicetree_enumerate(devicetree);
+
   // Print the devices that have been created.
   print_devices();
 

--- a/src/kernel/main.c
+++ b/src/kernel/main.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
+#include <device.h>
 #include <devicetree.h>
 #include <hart_locals.h>
 #include <init.h>
@@ -47,6 +48,9 @@ void main(u64 hart_id, paddr devicetree_start, paddr kernel_start,
 
   // Run initializers, which include e.g. registering drivers.
   run_initializers();
+
+  // Print the devices that have been created.
+  print_devices();
 
   print("Running self-tests...");
   run_selftests();

--- a/src/kernel/main.c
+++ b/src/kernel/main.c
@@ -6,6 +6,7 @@
 
 #include <devicetree.h>
 #include <hart_locals.h>
+#include <init.h>
 #include <mm/alloc.h>
 #include <mm/physical_alloc.h>
 #include <mm/virtual_alloc.h>
@@ -43,6 +44,9 @@ void main(u64 hart_id, paddr devicetree_start, paddr kernel_start,
   assert(vma_alloc_by_addr(&kernel_virtual_allocator, 0xffffffe000400000,
                            0xffffffe000600000));
   vma_allocator_print(&kernel_virtual_allocator);
+
+  // Run initializers, which include e.g. registering drivers.
+  run_initializers();
 
   print("Running self-tests...");
   run_selftests();

--- a/src/kernel/mm/alloc.c
+++ b/src/kernel/mm/alloc.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/mm/alloc/block.c
+++ b/src/kernel/mm/alloc/block.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/mm/alloc/block.h
+++ b/src/kernel/mm/alloc/block.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/mm/alloc/heap.c
+++ b/src/kernel/mm/alloc/heap.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/mm/alloc/heap.h
+++ b/src/kernel/mm/alloc/heap.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/mm/alloc/init.c
+++ b/src/kernel/mm/alloc/init.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/mm/alloc/page.c
+++ b/src/kernel/mm/alloc/page.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/mm/alloc/page.h
+++ b/src/kernel/mm/alloc/page.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/mm/alloc/segment.c
+++ b/src/kernel/mm/alloc/segment.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/mm/alloc/segment.h
+++ b/src/kernel/mm/alloc/segment.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/mm/alloc/size_classes.h
+++ b/src/kernel/mm/alloc/size_classes.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/mm/physical_alloc.c
+++ b/src/kernel/mm/physical_alloc.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/mm/virtual_alloc.c
+++ b/src/kernel/mm/virtual_alloc.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/panic.c
+++ b/src/kernel/panic.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/print.c
+++ b/src/kernel/print.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/random.c
+++ b/src/kernel/random.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/selftest.c
+++ b/src/kernel/selftest.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/swar_test.c
+++ b/src/kernel/swar_test.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/kernel/symbolicate.c
+++ b/src/kernel/symbolicate.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 ukoOS Contributors
+ * SPDX-FileCopyrightText: ukoOS Contributors
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */

--- a/src/targets/riscv64/milkv-duos.mak
+++ b/src/targets/riscv64/milkv-duos.mak
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+# SPDX-FileCopyrightText: ukoOS Contributors
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/targets/riscv64/milkv-jupiter.mak
+++ b/src/targets/riscv64/milkv-jupiter.mak
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+# SPDX-FileCopyrightText: ukoOS Contributors
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/targets/riscv64/qemu-riscv64.mak
+++ b/src/targets/riscv64/qemu-riscv64.mak
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 ukoOS Contributors
+# SPDX-FileCopyrightText: ukoOS Contributors
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 


### PR DESCRIPTION
On top of https://github.com/UMN-Kernel-Object/ukoos/pull/63; merge that one first, then rebase this.

---

- Adds initializers. These are used to register drivers with the appropriate subsystems.
- Adds the device model and documentation about it.
- Adds support for enumerating devices in the Devicetree.
- Adds the UART device class.
- Adds an incomplete ns16550a driver. This is the UART we get in QEMU, and _most_ UARTs in the wild are compatible with it. This driver is currently very basic, since we don't have interrupts (#9) and it doesn't do DMA.

---

Relevant to #10, but it is **not** resolved by this PR.

The UART device class and ns16550a driver here are not very finished.
They currently act as an example of the device model, but don't implement all of what's needed for the driver itself.