### PR TITLE
Declare nullptr_t ourselves.

### DIFF
--- a/src/kernel/include/types.h
+++ b/src/kernel/include/types.h
@@ -85,6 +85,12 @@ static_assert(alignof(uaddr) == __SIZEOF_SIZE_T__,
               "incorrect alignment for uaddr");
 
 /**
+ * The type of null pointers.
+ */
+
+typedef typeof(nullptr) nullptr_t;
+
+/**
  * Strict provenance functions. See [0] for more details, but these are
  * basically APIs for doing "funny things" to pointers that compile better on
  * architectures like CHERI or Fil-C than arbitrary int2ptr casts.


### PR DESCRIPTION
See [GCC bug #114869](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114869) -- the `nullptr_t` type is not actually specified as being built-in. This is the way it's now declared in gcc's `stddef.h`.