### PR TITLE
Misc stuff (yeah, bad title)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,4 +23,5 @@ RUN apk add --no-interactive \
 	shellcheck \
 	tar \
 	tio \
+	watchexec \
 	zstd

--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -12,6 +12,8 @@
   - [Init Functions](./kernel/init.md)
   - [Devices](./kernel/devices.md)
   - [Threads and Harts](./kernel/threads-and-harts.md)
+  - [Containers]()
+    - [Lists](./kernel/containers/lists.md)
   - [Memory management]()
     - [Overview](./kernel/mm/overview.md)
     - [Memory map](./kernel/mm/memory-map.md)

--- a/doc/kernel/containers/lists.md
+++ b/doc/kernel/containers/lists.md
@@ -1,0 +1,85 @@
+# Lists
+
+Many resources in the ukoOS kernel need to be in some registry.
+For example, devices of a certain device class (e.g. UARTs) generally need to be in some list, so that the kernel can iterate through all UARTs.
+Lists (`struct list_head`, after the same structure in Linux) allow for this in ukoOS.
+See `src/kernel/include/list.h` for the actual list API.
+
+ukoOS lists are doubly-linked circular *intrusive* linked lists; that is, rather than the list containing the element in some way (whether by having a pointer that points to it or by including it in each link's memory allocation), elements contain the link.
+
+For example, let's say we had a list of RGB colors and names.
+We might write that data structure as:
+
+```c
+struct named_color {
+    struct list_head list;
+    const char *name;
+    u8 r, g, b;
+};
+```
+
+This might seem strange, but it has one big advantage over a container that owns its data -- elements can belong to multiple lists.
+For example, pretend we had both an `all_colors` list and a `favorite_colors` list:
+
+```c
+struct named_color {
+    struct list_head all_colors;
+    struct list_head favorite_colors;
+    const char *name;
+    u8 r, g, b;
+};
+```
+
+This lets the color be in both lists at once.
+
+Lists are intended to have a single owning node / sentinel node.
+This is **not** embedded in the structure like other nodes are, but stands alone, often as a global:
+
+```c
+struct named_color {
+    struct list_head all_colors;
+    struct list_head favorite_colors;
+    const char *name;
+    u8 r, g, b;
+};
+
+struct list_head all_colors = LIST_INIT(all_colors);
+struct list_head favorite_colors = LIST_INIT(favorite_colors);
+```
+
+Since the lists are circular, we can use this sentinel node to know when we've reached the end of the list.
+
+We can also use this to create a tree:
+
+```c
+struct tree_node {
+    /**
+     * The parent of this node.
+     */
+    struct tree_node *parent;
+
+    /**
+     * This node's link in its parent's children.
+     */
+    struct list_head list;
+
+    /**
+     * This node's children.
+     */
+    struct list_head children;
+};
+```
+
+The `container_of` macro can be used to go from a `struct list_head *` to a `struct tree_node *`:
+
+```c
+struct tree_node node = { /* ... */ };
+
+struct list_head *ptr1 = &node.list;
+struct tree_node *node1 = container_of(ptr1, struct tree_node, list);
+assert(node1 == &node);
+
+struct list_head *ptr2 = &node.children;
+struct tree_node *node2 = container_of(ptr2, struct tree_node, children);
+assert(node2 == &node);
+```

--- a/doc/kernel/print.md
+++ b/doc/kernel/print.md
@@ -71,6 +71,18 @@ This directive expects a C `bool` in the arguments to `print` or `format`.
 It prints either `true` or `false`, corresponding to the value.
 This directive does not take any arguments.
 
+### `bytes`
+
+This directive expects a C `const u8 *` and a C `usize` in the arguments to `print` or `format`.
+
+It treats these as an array of bytes and prints each byte.
+By default, bytes are printed in hex with a space between each byte.
+The following arguments are supported:
+
+- `?`:
+  Wraps the bytes in `[]`.
+  If the bytes are all printable ASCII or have simple escape sequences in C, they get wrapped in `""`s and escaped if necessary.
+
 ### `cstr`
 
 This directive expects a C `const char *` in the arguments to `print` or `format`.

--- a/flake.lock
+++ b/flake.lock
@@ -63,11 +63,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758996538,
-        "narHash": "sha256-6z5h63WwMqJ4Rk76JFTAnpRHUFanFb0H0g2CGkwwRMo=",
+        "lastModified": 1771036519,
+        "narHash": "sha256-Vr6qv9duNwWigWqn0I+cWukStv+nrIYbiROpU7cuZWM=",
         "owner": "UMN-Kernel-Object",
         "repo": "u-boot",
-        "rev": "056f6b8ea3667470562486ccda79f71ec5acf1eb",
+        "rev": "2fe9d349ac8afb59f743aa3321319648551a7df8",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,7 @@
               pkgs.pkgsCross.riscv64-embedded.stdenv.cc.bintools.bintools
               pkgs.pkgsCross.riscv64-embedded.stdenv.cc.cc
               pkgs.python3
+              pkgs.watchexec
             ];
 
             dontUnpack = true;

--- a/flake.nix
+++ b/flake.nix
@@ -90,6 +90,7 @@
           ];
           nativeBuildInputs = [
             pkgs.bear
+            (pkgs.runCommand "busybox" { } "install -Dt $out/bin ${pkgs.pkgsStatic.busybox}/bin/busybox")
             pkgs.clang-tools
             pkgs.dtc
             pkgs.gdb
@@ -99,6 +100,7 @@
             pkgs.reuse
             pkgs.shellcheck
             pkgs.tio
+            pkgs.watchexec
           ];
           shellHook = ''
             export CC=riscv64-none-elf-gcc

--- a/src/kernel/builtins/strnlen.c
+++ b/src/kernel/builtins/strnlen.c
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: ukoOS Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <types.h>
+
+[[gnu::nonnull(1), gnu::pure]] usize strnlen(const char *s, usize max_len) {
+  usize n = 0;
+  while (max_len-- && *s++)
+    n++;
+  return n;
+}

--- a/src/kernel/devicetree.c
+++ b/src/kernel/devicetree.c
@@ -641,7 +641,7 @@ void devicetree_print(struct devicetree_node *node) {
          prop_list != &node->props; prop_list = prop_list->next) {
       struct devicetree_prop *prop =
           container_of(prop_list, struct devicetree_prop, node_props_head);
-      print("{indent}{cstr} = [{bytes}];", depth, prop->name, prop->value,
+      print("{indent}{cstr} = {bytes:?};", depth, prop->name, prop->value,
             prop->value_len);
     }
 

--- a/src/kernel/include.mak
+++ b/src/kernel/include.mak
@@ -28,6 +28,7 @@ kernel-objs-c += builtins/memcpy
 kernel-objs-c += builtins/memset
 kernel-objs-c += builtins/strcmp
 kernel-objs-c += builtins/strlen
+kernel-objs-c += builtins/strnlen
 kernel-objs-c += crypto/subtle/rfc7539
 kernel-objs-c += crypto/subtle/rfc7693
 kernel-objs-c += device

--- a/src/kernel/include/compiler.h
+++ b/src/kernel/include/compiler.h
@@ -163,4 +163,7 @@ int strcmp(const char *s1, const char *s2);
 [[gnu::nonnull(1), gnu::pure]]
 __SIZE_TYPE__ strlen(const char *s);
 
+[[gnu::nonnull(1), gnu::pure]]
+__SIZE_TYPE__ strnlen(const char *s, __SIZE_TYPE__ max_len);
+
 #endif // UKO_OS_KERNEL__COMPILER_H

--- a/src/kernel/print.c
+++ b/src/kernel/print.c
@@ -196,20 +196,99 @@ static void format_bool(struct formatter *fmt, const char *args_start,
 
 static void format_bytes(struct formatter *fmt, const char *args_start,
                          const char *args_end, va_list *ap) {
-  if (args_start != args_end) {
-    write_str(fmt, "{{invalid arguments for type bytes: ");
-    write_stri(fmt, args_start, args_end);
-    write_str(fmt, "}}");
-    return;
+  bool string_like = false;
+  const char *args = args_start;
+
+  while (args != args_end) {
+    char ch = *args++;
+    switch (ch) {
+    case '?':
+      if (!string_like) {
+        string_like = true;
+        break;
+      }
+    default:
+      write_str(fmt, "{{invalid arguments for type bytes: ");
+      write_stri(fmt, args_start, args_end);
+      write_str(fmt, "}}");
+      return;
+    }
   }
 
   const u8 *ptr = va_arg(*ap, const u8 *);
   usize len = va_arg(*ap, usize);
-  for (usize i = 0; i < len; i++) {
-    if (i)
-      write_byte(fmt, ' ');
-    write_byte(fmt, NUMBER_ALPHABET[ptr[i] >> 4]);
-    write_byte(fmt, NUMBER_ALPHABET[ptr[i] & 15]);
+  if (string_like) {
+    bool all_printable = true;
+    for (usize i = 0; i < len; i++) {
+      switch (ptr[i]) {
+      case '\0':
+      case '\a':
+      case '\b':
+      case '\f':
+      case '\n':
+      case '\r':
+      case '\t':
+      case '\v':
+      case ' ' ... '~':
+        continue;
+      default:
+        all_printable = false;
+        goto after_printable_check;
+      }
+    }
+  after_printable_check:
+
+    if (all_printable) {
+      write_byte(fmt, '\"');
+      for (usize i = 0; i < len; i++) {
+        switch (ptr[i]) {
+        case '\0':
+          write_str(fmt, "\\0");
+          break;
+        case '\a':
+          write_str(fmt, "\\a");
+          break;
+        case '\b':
+          write_str(fmt, "\\b");
+          break;
+        case '\f':
+          write_str(fmt, "\\f");
+          break;
+        case '\n':
+          write_str(fmt, "\\n");
+          break;
+        case '\r':
+          write_str(fmt, "\\r");
+          break;
+        case '\t':
+          write_str(fmt, "\\t");
+          break;
+        case '\v':
+          write_str(fmt, "\\v");
+          break;
+        case ' ' ... '~':
+          write_byte(fmt, ptr[i]);
+          break;
+        }
+      }
+      write_byte(fmt, '\"');
+    } else {
+      write_byte(fmt, '[');
+      for (usize i = 0; i < len; i++) {
+        if (i)
+          write_byte(fmt, ' ');
+        write_byte(fmt, NUMBER_ALPHABET[ptr[i] >> 4]);
+        write_byte(fmt, NUMBER_ALPHABET[ptr[i] & 15]);
+      }
+      write_byte(fmt, ']');
+    }
+  } else {
+    for (usize i = 0; i < len; i++) {
+      if (i)
+        write_byte(fmt, ' ');
+      write_byte(fmt, NUMBER_ALPHABET[ptr[i] >> 4]);
+      write_byte(fmt, NUMBER_ALPHABET[ptr[i] & 15]);
+    }
   }
 }
 

--- a/src/targets/riscv64/qemu-riscv64.mak
+++ b/src/targets/riscv64/qemu-riscv64.mak
@@ -2,5 +2,5 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-kernel-cflags += -march=rv64imac_zicsr_zicntr_zihpm_zba_zbb_zbs_zihintpause_zicbom_zicbop_zicboz
-target-qemuflags = --machine virt --cpu rva22s64 --smp 1 -m 1G --netdev user,id=net0 -device rtl8139,netdev=net0,bus=pcie.0
+kernel-cflags += -march=rv64imafdcbv_zicsr_zicntr_zihpm_ziccif_ziccrse_ziccamoa_zicclsm_zic64b_za64rs_zihintpause_zba_zbb_zbs_zicbom_zicbop_zicboz_zfhmin_zkt_zvfhmin_zvbb_zvkt_zihintntl_zicond_zimop_zcmop_zcb_zfa_zawrs_svpbmt_svinval_svnapot_sstc_sscofpmf_zifencei
+target-qemuflags = --machine virt --cpu rva23s64 --smp 1 -m 1G --netdev user,id=net0 -device rtl8139,netdev=net0,bus=pcie.0

--- a/src/targets/riscv64/qemu-riscv64.mak
+++ b/src/targets/riscv64/qemu-riscv64.mak
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 kernel-cflags += -march=rv64imafdcbv_zicsr_zicntr_zihpm_ziccif_ziccrse_ziccamoa_zicclsm_zic64b_za64rs_zihintpause_zba_zbb_zbs_zicbom_zicbop_zicboz_zfhmin_zkt_zvfhmin_zvbb_zvkt_zihintntl_zicond_zimop_zcmop_zcb_zfa_zawrs_svpbmt_svinval_svnapot_sstc_sscofpmf_zifencei
-target-qemuflags = --machine virt --cpu rva23s64 --smp 1 -m 1G --netdev user,id=net0 -device rtl8139,netdev=net0,bus=pcie.0
+target-qemuflags = --machine virt --cpu rva23s64 --smp 2 -m 1G --netdev user,id=net0 -device rtl8139,netdev=net0,bus=pcie.0

--- a/tools/build-each-commit.sh
+++ b/tools/build-each-commit.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: ukoOS Contributors
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -euo pipefail
+
+repo=$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")
+cd "$repo"
+export repo
+
+# Check that there are no uncommitted changes (they'll get nuked if so).
+if [[ -n "$(git status --porcelain)" ]]; then
+	printf >&2 'There were uncommitted changes; please stash or delete them.\n'
+	exit 1
+fi
+
+# Find the commit to restore to.
+head=$(git rev-parse HEAD)
+
+# Make a temporary directory for the build.
+tmp=$(mktemp -d)
+export tmp
+
+# On exit, delete the temporary directory and go back to the saved commit.
+cleanup() {
+	rm -r "$tmp"
+	if [[ -f .git/ORIG_HEAD ]]; then
+		git rebase --abort
+	else
+		git reset --hard "$head"
+	fi
+}
+trap cleanup EXIT
+
+# Assemble the command.
+cmd="head=\$(git rev-parse HEAD)"
+cmd+=" && dir=\"\$tmp/\$head\""
+cmd+=" && reuse lint"
+cmd+=" && mkdir \"\$dir\""
+cmd+=" && (cd \"\$dir\" && \"\$repo/configure\" --target qemu-riscv64)"
+cmd+=" && make -C \"\$dir\" clean"
+cmd+=" && make -C \"\$dir\" -j $(nproc) -l $(nproc)"
+
+# Checks that each commit since trunk builds.
+git rebase \
+	--exec "$cmd" \
+	--interactive \
+	"${1:-trunk}"

--- a/tools/build-each-commit.sh
+++ b/tools/build-each-commit.sh
@@ -35,13 +35,17 @@ cleanup() {
 trap cleanup EXIT
 
 # Assemble the command.
-cmd="head=\$(git rev-parse HEAD)"
-cmd+=" && dir=\"\$tmp/\$head\""
-cmd+=" && reuse lint"
-cmd+=" && mkdir \"\$dir\""
-cmd+=" && (cd \"\$dir\" && \"\$repo/configure\" --target qemu-riscv64)"
-cmd+=" && make -C \"\$dir\" clean"
-cmd+=" && make -C \"\$dir\" -j $(nproc) -l $(nproc)"
+cmd=(
+'head=$(git rev-parse HEAD)'
+'&& dir="$tmp/$head"'
+'&& reuse lint'
+'&& mkdir "$dir"'
+'&& (cd "$dir" && "$repo/configure" --target qemu-riscv64)'
+'&& make -C "$dir" clean'
+"make -C \"\$dir\" -j $(nproc) -l $(nproc)"
+)
+cmd=${cmd[*]}
+
 
 # Checks that each commit since trunk builds.
 git rebase \


### PR DESCRIPTION
On top of https://github.com/UMN-Kernel-Object/ukoos/pull/70; merge that one first, then rebase this.

---

- Adds a script for doing a basic build test of each commit in a PR since `trunk` (or since another ref).
- Switches the qemu-riscv64 target to RVA23, since hardware that implements that is becoming available (#90).
- Makes the qemu-riscv64 target dual-core, so we can test multicore behavior with it.
- Adds some dependencies (busybox, watchexec) that weren't already specified in the flake.
- Documents lists and the `bytes` format directive.
- Adds the `{bytes:?}` flag to the `bytes` format directive.
- Updates the Milk-V Duo S U-Boot to include [2fe9d34](https://github.com/UMN-Kernel-Object/u-boot/commit/2fe9d349ac8afb59f743aa3321319648551a7df8), which adds properties to its devicetree that supersede some older, deprecated ones.
- Adds the `strnlen` builtin function.