### PR TITLE
Hart drivers

### DIFF
--- a/src/kernel/arch/riscv64/hart_group.c
+++ b/src/kernel/arch/riscv64/hart_group.c
@@ -1,0 +1,130 @@
+/*
+ * SPDX-FileCopyrightText: ukoOS Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <arch/riscv64/drivers/riscv_cpu.h>
+#include <mm/alloc.h>
+
+// TODO: This should become a hashtable, but this isn't _so_ horrible right now,
+// since there won't be very many hart groups or harts.
+
+struct riscv_hart_group_list {
+  struct riscv_hart_group_list *next;
+  struct riscv_hart_group_key key;
+  struct riscv_hart_group group;
+};
+
+static struct riscv_hart_group_list *hart_groups = nullptr;
+
+static bool riscv_hart_group_key_eq(struct riscv_hart_group_key key1,
+                                    struct riscv_hart_group_key key2) {
+  return key1.cboz_block_size == key2.cboz_block_size &&
+         key1.flen == key2.flen && key1.vlen == key2.vlen;
+}
+
+static void riscv_hart_group_make(struct riscv_hart_group *group,
+                                  struct riscv_hart_group_key key) {
+  usize len = 0;
+
+  // X
+  group->x_off = len;
+  group->x_len = 32 * sizeof(u64); // We don't support rv32, rv64e, or rv64y
+  len += group->x_len;
+
+  // F
+  if (key.flen != FLEN_0) {
+    usize sizeof_f;
+    switch (key.flen) {
+    case FLEN_0:
+      sizeof_f = 0;
+      break;
+    case FLEN_32:
+      sizeof_f = 4;
+      break;
+    case FLEN_64:
+      sizeof_f = 8;
+      break;
+    case FLEN_128:
+      sizeof_f = 16;
+      break;
+    }
+    len = (len + sizeof_f - 1) & ~(sizeof_f - 1);
+    group->f_off = len;
+    group->f_len = 32 * sizeof_f;
+    len += group->f_len;
+  } else {
+    group->f_off = 0;
+    group->f_len = 0;
+  }
+
+  // V
+  if (key.vlen != VLEN_0) {
+    usize sizeof_v;
+    switch (key.vlen) {
+    case VLEN_UNKNOWN:
+    default:
+      panic("hart group key was not fully determined");
+    case VLEN_0:
+      sizeof_v = 0;
+      break;
+    case VLEN_128:
+      sizeof_v = 16;
+      break;
+    case VLEN_256:
+      sizeof_v = 32;
+      break;
+    case VLEN_512:
+      sizeof_v = 64;
+      break;
+    case VLEN_1024:
+      sizeof_v = 128;
+      break;
+    case VLEN_2048:
+      sizeof_v = 256;
+      break;
+    case VLEN_4096:
+      sizeof_v = 512;
+      break;
+    case VLEN_8192:
+      sizeof_v = 1024;
+      break;
+    case VLEN_16384:
+      sizeof_v = 2048;
+      break;
+    case VLEN_32768:
+      sizeof_v = 4096;
+      break;
+    case VLEN_65536:
+      sizeof_v = 8192;
+      break;
+    }
+    len = (len + 7) & ~(usize)7;
+    group->v_off = len;
+    group->v_len = 32 * sizeof_v;
+    len += group->v_len;
+  } else {
+    group->v_off = 0;
+    group->v_len = 0;
+  }
+
+  group->hart_group.sizeof_register_save_area = len;
+}
+
+struct riscv_hart_group *riscv_hart_group_get(struct riscv_hart_group_key key) {
+  struct riscv_hart_group_list *link;
+
+  for (link = hart_groups; link; link = link->next)
+    if (riscv_hart_group_key_eq(key, link->key))
+      return &link->group;
+
+  link = alloc(sizeof(struct riscv_hart_group_list));
+  if (!link)
+    return nullptr;
+  link->next = hart_groups;
+  link->key = key;
+  riscv_hart_group_make(&link->group, key);
+  hart_groups = link;
+  return &link->group;
+}

--- a/src/kernel/arch/riscv64/hart_locals.c
+++ b/src/kernel/arch/riscv64/hart_locals.c
@@ -5,24 +5,60 @@
  */
 
 #include <arch/riscv64/insns.h>
+#include <device.h>
 #include <hart_locals.h>
 
 /**
  * Storage for the boothart's hart-locals.
  */
-struct hart_locals boothart_hart_locals;
+static struct hart_locals boothart_hart_locals;
+
+/**
+ * The boothart's hart ID.
+ */
+static u64 boothart_hart_id;
+
+/**
+ * Modifies a heap to change the hart that owns it. This is only needed when
+ * initializing the boothart, so it's declared here instead of in a public
+ * header.
+ */
+void heap_change_boothart_hart(struct mm_alloc_heap *heap, struct hart *hart);
 
 struct hart_locals *get_hart_locals(void) {
   return (struct hart_locals *)csrr(RISCV64_CSR_SSCRATCH);
 }
 
-void init_boothart_hart_locals(u64 hart_id) {
+void init_boothart_hart_locals_early(u64 hart_id) {
+  boothart_hart_id = hart_id;
   csrw(RISCV64_CSR_SSCRATCH, (u64)&boothart_hart_locals);
   boothart_hart_locals = (struct hart_locals){
       .hart_id = hart_id,
       .heap = nullptr,
       .rng = {},
   };
+}
+
+void init_boothart_hart_locals_late(void) {
+  // Reallocate the hart-locals to be heap-allocated.
+  struct hart_locals *hart_locals = alloc(sizeof(struct hart_locals));
+  memcpy(hart_locals, &boothart_hart_locals, sizeof(struct hart_locals));
+  csrw(RISCV64_CSR_SSCRATCH, (u64)hart_locals);
+
+  // Find the hart object with the current hart ID, and ensure that it has a
+  // hart group.
+  for (struct list_head *hart_list = harts.next; hart_list != &harts;
+       hart_list = hart_list->next) {
+    struct hart *hart = container_of(hart_list, struct hart, list);
+    if (hart->id == boothart_hart_id) {
+      hart_locals->hart = hart;
+      break;
+    }
+  }
+  if (!hart_locals->hart) {
+    print_devices();
+    panic("Could not find a hart with the ID {u64}", boothart_hart_id);
+  }
 }
 
 void init_hart_locals(u64 hart_id);

--- a/src/kernel/arch/riscv64/include.mak
+++ b/src/kernel/arch/riscv64/include.mak
@@ -9,6 +9,7 @@ kernel-cflags += \
 	-mcmodel=medany
 kernel-objs-asm += arch/riscv64/start
 kernel-objs-c += arch/riscv64/backtrace
+kernel-objs-c += arch/riscv64/hart_group
 kernel-objs-c += arch/riscv64/hart_locals
 kernel-objs-c += arch/riscv64/paging
 kernel-objs-c += arch/riscv64/panic

--- a/src/kernel/devices/hart.c
+++ b/src/kernel/devices/hart.c
@@ -1,0 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: ukoOS Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <devices/hart.h>
+
+struct list_head harts = LIST_INIT(harts);

--- a/src/kernel/drivers/include.mak
+++ b/src/kernel/drivers/include.mak
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 kernel-objs-c += drivers/ns16550a
+kernel-objs-c += drivers/riscv_cpu

--- a/src/kernel/drivers/riscv_cpu.c
+++ b/src/kernel/drivers/riscv_cpu.c
@@ -1,0 +1,264 @@
+/*
+ * SPDX-FileCopyrightText: ukoOS Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <arch/riscv64/drivers/riscv_cpu.h>
+#include <arch/riscv64/insns.h>
+#include <devices/hart.h>
+#include <devicetree.h>
+#include <endian.h>
+#include <mm/paging.h>
+#include <physical.h>
+#include <stdatomic.h>
+
+struct riscv_cpu {
+  struct device device;
+  struct hart hart;
+
+  atomic struct riscv_hart_group_key hart_group_key;
+};
+
+static inline enum riscv_vlen vlenb_to_riscv_vlen(u64 vlenb) {
+  switch (vlenb) {
+  case 16:
+    return VLEN_128;
+  case 32:
+    return VLEN_256;
+  case 64:
+    return VLEN_512;
+  case 128:
+    return VLEN_1024;
+  case 256:
+    return VLEN_2048;
+  case 512:
+    return VLEN_4096;
+  case 1024:
+    return VLEN_8192;
+  case 2048:
+    return VLEN_16384;
+  case 4096:
+    return VLEN_32768;
+  case 8192:
+    return VLEN_65536;
+  default:
+    return VLEN_UNKNOWN;
+  }
+}
+
+static void riscv_cpu_detect_hart_group(struct hart *hart) {
+  assert(get_hart_locals()->hart == hart);
+  assert(!hart->hart_group);
+  struct riscv_cpu *this = container_of(hart, struct riscv_cpu, hart);
+
+  // Currently, this is the only reason we wouldn't have assigned a hart group
+  // yet.
+  struct riscv_hart_group_key hart_group_key = this->hart_group_key;
+  assert(hart_group_key.vlen == VLEN_UNKNOWN);
+
+  u64 vlenb = csrr(RISCV64_CSR_VLENB);
+  hart_group_key.vlen = vlenb_to_riscv_vlen(vlenb);
+  if (hart_group_key.vlen == VLEN_UNKNOWN) {
+    print("Hart {u64} had a spec-disallowed value for vlenb ({u64}); disabling "
+          "the V extension",
+          hart->id, vlenb);
+    hart_group_key.vlen = VLEN_0;
+  }
+
+  // We should now be able to assign a hart group.
+  struct riscv_hart_group *hart_group = riscv_hart_group_get(hart_group_key);
+  assert(hart_group);
+  this->hart_group_key = hart_group_key;
+  hart->hart_group = &hart_group->hart_group;
+}
+
+const struct hart_ops riscv_cpu_hart_ops = {
+    .detect_hart_group = riscv_cpu_detect_hart_group,
+};
+
+static bool extensions_list_has_extension(const u8 *value, usize value_len,
+                                          const char *extension_name) {
+  usize extension_name_len = strlen(extension_name);
+  while (value_len) {
+    usize ext_len = strnlen((const char *)value, value_len);
+    if (ext_len == extension_name_len &&
+        memcmp(extension_name, value, ext_len) == 0) {
+      return true;
+    }
+    value += ext_len + 1;
+    value_len -= ext_len + 1;
+  }
+  return false;
+}
+
+static u32 get_cboz_block_size_from_extensions(
+    struct devicetree_node *node, struct devicetree_prop *prop_isa_extensions) {
+  u32 cboz_block_size = 0;
+  if (extensions_list_has_extension(prop_isa_extensions->value,
+                                    prop_isa_extensions->value_len, "zicboz")) {
+    u32 block_size;
+    struct devicetree_prop *prop_cboz_block_size =
+        devicetree_prop(node, "riscv,cboz-block-size");
+    if (prop_cboz_block_size) {
+      if (prop_cboz_block_size->value_len == sizeof(block_size)) {
+        memcpy(&block_size, prop_cboz_block_size->value, sizeof(block_size));
+        block_size = big_to_native(block_size);
+
+        cboz_block_size = block_size;
+      } else {
+        print("Devicetree device {cstr} did not have the riscv,cboz-block-size "
+              "property",
+              node->name);
+      }
+    } else {
+      print("Devicetree device {cstr} had the wrong size for the "
+            "riscv,cboz-block-size property",
+            node->name);
+    }
+  }
+  return cboz_block_size;
+}
+
+static enum riscv_flen
+get_flen_from_extensions(struct devicetree_prop *prop_isa_extensions) {
+  if (extensions_list_has_extension(prop_isa_extensions->value,
+                                    prop_isa_extensions->value_len, "q")) {
+    return FLEN_128;
+  } else if (extensions_list_has_extension(prop_isa_extensions->value,
+                                           prop_isa_extensions->value_len,
+                                           "d")) {
+    return FLEN_64;
+  } else if (extensions_list_has_extension(prop_isa_extensions->value,
+                                           prop_isa_extensions->value_len,
+                                           "f")) {
+    return FLEN_32;
+  } else {
+    return FLEN_0;
+  }
+}
+
+static enum riscv_vlen
+get_vlen_from_extensions(struct devicetree_node *node,
+                         struct devicetree_prop *prop_isa_extensions) {
+  enum riscv_vlen vlen;
+
+  if (extensions_list_has_extension(prop_isa_extensions->value,
+                                    prop_isa_extensions->value_len, "v")) {
+    vlen = VLEN_UNKNOWN;
+
+    u32 vlenb;
+    struct devicetree_prop *prop_thead_vlenb =
+        devicetree_prop(node, "thead,vlenb");
+    if (prop_thead_vlenb) {
+      if (prop_thead_vlenb->value_len == sizeof(vlenb)) {
+        memcpy(&vlenb, prop_thead_vlenb->value, sizeof(vlenb));
+        vlenb = big_to_native(vlenb);
+        vlen = vlenb_to_riscv_vlen(vlenb);
+        if (vlen == VLEN_UNKNOWN) {
+          print("Devicetree device {cstr} had a spec-disallowed value for the "
+                "thead,vlenb property ({u32})",
+                node->name, vlenb);
+        }
+      } else {
+        print("Devicetree device {cstr} had the wrong size for the thead,vlenb "
+              "property",
+              node->name);
+      }
+    } else {
+      print("Devicetree device {cstr} did not have the thead,vlenb property",
+            node->name);
+    }
+  } else {
+    vlen = VLEN_0;
+  }
+
+  return vlen;
+}
+
+static struct device *riscv_cpu_enumerate_dt(struct devicetree_node *node) {
+  struct riscv_cpu *device = nullptr;
+  struct devicetree_prop *prop_reg, *prop_isa_base, *prop_isa_extensions;
+  u32 id;
+
+  // Get the hart number.
+  prop_reg = devicetree_prop(node, "reg");
+  if (!prop_reg) {
+    print("Devicetree device {cstr} was missing the reg property", node->name);
+    goto fail;
+  }
+  if (prop_reg->value_len != sizeof(id)) {
+    print("Devicetree device {cstr} had the wrong size for the reg property",
+          node->name);
+    goto fail;
+  }
+  memcpy(&id, prop_reg->value, sizeof(id));
+  id = big_to_native(id);
+
+  // Check for the ISA the hart supports.
+  prop_isa_base = devicetree_prop(node, "riscv,isa-base");
+  prop_isa_extensions = devicetree_prop(node, "riscv,isa-extensions");
+  if (!prop_isa_base || !prop_isa_extensions) {
+    if (devicetree_prop(node, "riscv,isa")) {
+      print("Devicetree device {cstr} has the riscv,isa property but not "
+            "riscv,isa-base and riscv,isa-extensions; update the Devicetree",
+            node->name);
+    }
+    goto fail;
+  }
+
+  if (prop_isa_base->value_len != 6 ||
+      memcmp(prop_isa_base->value, "rv64i", 6) != 0) {
+    print("Devicetree device {cstr} was not rv64i", node->name);
+    goto fail;
+  }
+
+  // Allocate the device.
+  device = alloc(sizeof(struct riscv_cpu));
+  if (!device)
+    goto fail;
+  struct riscv_hart_group_key hart_group_key = {
+      .cboz_block_size =
+          get_cboz_block_size_from_extensions(node, prop_isa_extensions),
+      .flen = get_flen_from_extensions(prop_isa_extensions),
+      .vlen = get_vlen_from_extensions(node, prop_isa_extensions),
+  };
+  *device = (struct riscv_cpu){
+      .device = DEVICE_INIT(device->device, "riscv_cpu@{u32}", id),
+      .hart =
+          {
+              .list = LIST_INIT(device->hart.list),
+              .device = &device->device,
+              .hart_ops = &riscv_cpu_hart_ops,
+              .id = id,
+              .hart_group = nullptr,
+          },
+  };
+  atomic_init(&device->hart_group_key, hart_group_key);
+  if (!device->device.name)
+    goto fail;
+
+  // Try to assign a hart group now, if we can.
+  if (riscv_hart_group_key_is_fully_determined(device->hart_group_key)) {
+    struct riscv_hart_group *hart_group =
+        riscv_hart_group_get(device->hart_group_key);
+    if (!hart_group)
+      goto fail;
+    device->hart.hart_group = &hart_group->hart_group;
+  }
+
+  // Add the device to the list of harts and return.
+  list_push(&harts, &device->hart.list);
+  return &device->device;
+
+fail:
+  if (device) {
+    free(device->device.name);
+  }
+  free(device);
+  return nullptr;
+}
+
+DEFINE_INIT(INIT_REGISTER_DRIVERS) {
+  devicetree_register("riscv", riscv_cpu_enumerate_dt);
+}

--- a/src/kernel/include.mak
+++ b/src/kernel/include.mak
@@ -34,6 +34,7 @@ kernel-objs-c += builtins/strnlen
 kernel-objs-c += crypto/subtle/rfc7539
 kernel-objs-c += crypto/subtle/rfc7693
 kernel-objs-c += device
+kernel-objs-c += devices/hart
 kernel-objs-c += devices/uart
 kernel-objs-c += devicetree
 kernel-objs-c += init

--- a/src/kernel/include/arch/riscv64/drivers/riscv_cpu.h
+++ b/src/kernel/include/arch/riscv64/drivers/riscv_cpu.h
@@ -1,0 +1,109 @@
+/*
+ * SPDX-FileCopyrightText: ukoOS Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef UKO_OS_KERNEL__ARCH_RISCV64_DEVICES_HART_H
+#define UKO_OS_KERNEL__ARCH_RISCV64_DEVICES_HART_H 1
+
+#include <devices/hart.h>
+
+enum riscv_flen {
+  /**
+   * The F extension is not supported on this hart.
+   */
+  FLEN_0,
+
+  /**
+   * The F extension is supported on this hart, but the D and Q extensions are
+   * not.
+   */
+  FLEN_32,
+
+  /**
+   * The F and D extensions are supported on this hart, but the Q extension is
+   * not.
+   */
+  FLEN_64,
+
+  /**
+   * The F, D, and Q extensions are supported on this hart.
+   */
+  FLEN_128,
+};
+
+enum riscv_vlen {
+  /**
+   * The V extension is not supported on this hart.
+   */
+  VLEN_0,
+
+  /**
+   * This hart supports the V extension, but the VLEN of this hart is unknown
+   * until it boots (which it hasn't yet done).
+   */
+  VLEN_UNKNOWN,
+
+  VLEN_128,
+  VLEN_256,
+  VLEN_512,
+  VLEN_1024,
+  VLEN_2048,
+  VLEN_4096,
+  VLEN_8192,
+  VLEN_16384,
+  VLEN_32768,
+  VLEN_65536,
+};
+
+/**
+ * The key used to identify hart groups.
+ *
+ * This has to be small enough to be atomically updated thanks to the
+ * VLEN_UNKNOWN state -- we can't guarantee other harts aren't accessing it
+ * when the hart tries to take itself out of that state, so we need to use an
+ * atomic write to update it.
+ */
+struct riscv_hart_group_key {
+  /**
+   * If the Zicboz extension is supported, the size of a cache block. Otherwise,
+   * zero.
+   */
+  u32 cboz_block_size;
+  enum riscv_flen flen : 2;
+  enum riscv_vlen vlen : 4;
+  // TODO: Sstateen-based extensions
+};
+
+static_assert(sizeof(struct riscv_hart_group_key) <= sizeof(u64));
+
+/**
+ * Returns whether the riscv_hart_group_key has been filled out enough to use to
+ * find a hart group. This must be true before the hart enters the scheduler for
+ * the first time.
+ */
+static inline bool
+riscv_hart_group_key_is_fully_determined(struct riscv_hart_group_key key) {
+  return key.vlen != VLEN_UNKNOWN;
+}
+
+/**
+ * A hart group, plus some riscv64-specific extensions.
+ */
+struct riscv_hart_group {
+  struct hart_group hart_group;
+
+  // The offset and lengths in the register save area of the classes of GPRs.
+  usize x_off, f_off, v_off;
+  usize x_len, f_len, v_len;
+};
+
+/**
+ * Finds or creates a hart group for the given key.
+ *
+ * Panics if the key is not fully determined.
+ */
+struct riscv_hart_group *riscv_hart_group_get(struct riscv_hart_group_key key);
+
+#endif // UKO_OS_KERNEL__ARCH_RISCV64_DEVICES_HART_H

--- a/src/kernel/include/arch/riscv64/insns.h
+++ b/src/kernel/include/arch/riscv64/insns.h
@@ -34,6 +34,7 @@ enum csr {
   RISCV64_CSR_CYCLE = 0xc00,
   RISCV64_CSR_TIME = 0xc01,
   RISCV64_CSR_INSTRET = 0xc02,
+  RISCV64_CSR_VLENB = 0xc22,
 };
 
 /**

--- a/src/kernel/include/devices/hart.h
+++ b/src/kernel/include/devices/hart.h
@@ -1,0 +1,107 @@
+/*
+ * SPDX-FileCopyrightText: ukoOS Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef UKO_OS_KERNEL__DEVICES_HART_H
+#define UKO_OS_KERNEL__DEVICES_HART_H 1
+
+#include <list.h>
+
+// Avoids a circular include:
+//   devices/hart.h -> device.h       for struct device
+//   device.h -> print.h              for format()
+//   print.h -> mm/alloc.h            for free()
+//   mm/alloc.h -> hart_locals.h      for get_hart_locals().heap
+//   hart_locals.h -> devices/hart.h  for struct hart
+struct device;
+
+struct hart_ops;
+
+/**
+ * A hart device.
+ *
+ * Currently, these devices are for "normal" SMP systems, where each hart runs
+ * the same ukoOS kernel, makes its own scheduling decisions, etc. When we
+ * support "peripheral-like harts," it might make sense to give them their own
+ * device class rather than reusing this one.
+ */
+struct hart {
+  /**
+   * The list head used to link the hart into the `harts` list.
+   */
+  struct list_head list;
+
+  /**
+   * A pointer to the device.
+   */
+  struct device *device;
+
+  /**
+   * The hart's vtable.
+   */
+  const struct hart_ops *hart_ops;
+
+  /**
+   * The hart ID for this hart. Not guaranteed to be small or densely packed.
+   */
+  u64 id;
+
+  /**
+   * A pointer to the hart_group. This can be nullptr -- if it is, that means
+   * that the hart_group is not yet detectable (e.g. if it can only be
+   * determined after the hart boots and it has not yet booted).
+   */
+  struct hart_group *hart_group;
+};
+
+/**
+ * The operations for a hart.
+ */
+struct hart_ops {
+  /**
+   * Fills in the hart_group field by detecting information about the current
+   * hart.
+   *
+   * Requires:
+   *
+   * - `this->hart_group == nullptr`
+   * - `this == get_hart_locals()->hart`
+   *
+   * Ensures:
+   *
+   * - `this->hart_group != nullptr`
+   */
+  void (*detect_hart_group)(struct hart *this);
+};
+
+/**
+ * The list of all hart devices.
+ */
+extern struct list_head harts;
+
+/**
+ * A hart group contains shared data for harts that should be able to run the
+ * same tasks as each other.
+ *
+ * In an SMP system, there will be only one hart group, since any task can be
+ * run on any hart.
+ *
+ * An example of a more complicated system is the SpacemiT K3. This SoC has 8
+ * X100 cores, which have 256-bit vector regiters, and 8 A100 cores, which have
+ * 1024-bit vector registers. This would result in two hart groups, one for the
+ * X100 cores and one for the A100 cores.
+ *
+ * TODO: We just leak these for now. If we support CPU hotplug, we shouldn't do
+ * that, but that's not a near-term task.
+ */
+struct hart_group {
+  /**
+   * The total size of the register save area in `struct task` for tasks that
+   * run on this hart group, including any padding needed.
+   */
+  usize sizeof_register_save_area;
+};
+
+#endif // UKO_OS_KERNEL__DEVICES_HART_H

--- a/src/kernel/include/hart_locals.h
+++ b/src/kernel/include/hart_locals.h
@@ -8,6 +8,7 @@
 #define UKO_OS_KERNEL__HART_LOCALS_H 1
 
 #include <crypto/subtle/random_internals.h>
+#include <devices/hart.h>
 
 /**
  * The data that is local to a hart.
@@ -17,6 +18,16 @@ struct hart_locals {
    * The ID of the hart. Not guaranteed to be small or densely packed.
    */
   u64 hart_id;
+
+  /**
+   * A pointer to the current hart.
+   */
+  struct hart *hart;
+
+  /**
+   * The current task.
+   */
+  struct task *task;
 
   /**
    * The current heap.
@@ -38,11 +49,16 @@ struct hart_locals {
 struct hart_locals *get_hart_locals(void);
 
 /**
- * Called during early boot to initialize the boothart's hart-local storage.
- * This needs to be separate from `init_hart_locals`, because the allocator
- * won't be available yet.
+ * Called during early boot to initialize the boothart's hart-local storage
+ * enough to perform device discovery.
  */
-void init_boothart_hart_locals(u64 hart_id);
+void init_boothart_hart_locals_early(u64 hart_id);
+
+/**
+ * Called during early boot to finish initializing the boothart's hart-local
+ * storage.
+ */
+void init_boothart_hart_locals_late(void);
 
 /**
  * Called during hart bring-up to allocate hart-local storage for a hart.

--- a/src/kernel/main.c
+++ b/src/kernel/main.c
@@ -25,7 +25,7 @@ void main(u64 hart_id, paddr devicetree_start, paddr kernel_start,
   symbolicate_init(symtab, symtab_len, strtab, strtab_len);
   entropy_pool_init();
   arch_entropy_pool_seed_early();
-  init_boothart_hart_locals(hart_id);
+  init_boothart_hart_locals_early(hart_id);
   mm_alloc_init();
 
   // Parse the Devicetree.
@@ -49,11 +49,16 @@ void main(u64 hart_id, paddr devicetree_start, paddr kernel_start,
   // Run initializers, which include e.g. registering drivers.
   run_initializers();
 
-  // Enumerate devices in the devicetree.
+  // Enumerate devices in the devicetree. This should recursively enumerate
+  // other buses as they're discovered.
   devicetree_enumerate(devicetree);
 
   // Print the devices that have been created.
   print_devices();
+
+  // Finish initializing hart-locals, now that the root hart should have been
+  // detected.
+  init_boothart_hart_locals_late();
 
   print("Running self-tests...");
   run_selftests();


### PR DESCRIPTION
Stacked on #102.

We need to ensure that tasks are only scheduled on harts with the same
register_save_area size, meaning we need to track which harts have which
size.

It's easiest to keep track of this if we hook that tracking into
ordinary device detection, so this device class exists for that purpose.