### PR TITLE
support for allocating addresses below 32 bits

### DIFF
--- a/src/kernel/arch/riscv64/paging.c
+++ b/src/kernel/arch/riscv64/paging.c
@@ -111,7 +111,7 @@ static bool mm_paging_walk(uaddr va, paddr *pte, bool alloc) {
   if (!pte2.valid) {
     if (!alloc)
       return false;
-    if (!mm_alloc_physical(&pgtbl1, PAGING_DEFAULT))
+    if (!mm_alloc_physical(&pgtbl1, PHYSICAL_ALLOC_DEFAULT))
       return false;
     bzero_physical(pgtbl1, sizeof(struct pgtbl));
     pte2 = (struct pte){
@@ -127,7 +127,7 @@ static bool mm_paging_walk(uaddr va, paddr *pte, bool alloc) {
   if (!pte1.valid) {
     if (!alloc)
       return false;
-    if (!mm_alloc_physical(&pgtbl0, PAGING_DEFAULT))
+    if (!mm_alloc_physical(&pgtbl0, PHYSICAL_ALLOC_DEFAULT))
       return false;
     bzero_physical(pgtbl0, sizeof(struct pgtbl));
     pte1 = (struct pte){

--- a/src/kernel/arch/riscv64/paging.c
+++ b/src/kernel/arch/riscv64/paging.c
@@ -111,7 +111,7 @@ static bool mm_paging_walk(uaddr va, paddr *pte, bool alloc) {
   if (!pte2.valid) {
     if (!alloc)
       return false;
-    if (!mm_alloc_physical(&pgtbl1))
+    if (!mm_alloc_physical(&pgtbl1, above_4g_ok))
       return false;
     bzero_physical(pgtbl1, sizeof(struct pgtbl));
     pte2 = (struct pte){
@@ -127,7 +127,7 @@ static bool mm_paging_walk(uaddr va, paddr *pte, bool alloc) {
   if (!pte1.valid) {
     if (!alloc)
       return false;
-    if (!mm_alloc_physical(&pgtbl0))
+    if (!mm_alloc_physical(&pgtbl0, above_4g_ok))
       return false;
     bzero_physical(pgtbl0, sizeof(struct pgtbl));
     pte1 = (struct pte){

--- a/src/kernel/arch/riscv64/paging.c
+++ b/src/kernel/arch/riscv64/paging.c
@@ -111,7 +111,7 @@ static bool mm_paging_walk(uaddr va, paddr *pte, bool alloc) {
   if (!pte2.valid) {
     if (!alloc)
       return false;
-    if (!mm_alloc_physical(&pgtbl1, above_4g_ok))
+    if (!mm_alloc_physical(&pgtbl1, PAGING_DEFAULT))
       return false;
     bzero_physical(pgtbl1, sizeof(struct pgtbl));
     pte2 = (struct pte){
@@ -127,7 +127,7 @@ static bool mm_paging_walk(uaddr va, paddr *pte, bool alloc) {
   if (!pte1.valid) {
     if (!alloc)
       return false;
-    if (!mm_alloc_physical(&pgtbl0, above_4g_ok))
+    if (!mm_alloc_physical(&pgtbl0, PAGING_DEFAULT))
       return false;
     bzero_physical(pgtbl0, sizeof(struct pgtbl));
     pte1 = (struct pte){

--- a/src/kernel/include/mm/physical_alloc.h
+++ b/src/kernel/include/mm/physical_alloc.h
@@ -12,9 +12,9 @@
 /**
  * The possible flags to pass to the allocator
  */
-enum paging_flags {
-  PAGING_DEFAULT,
-  PAGING_BELOW_4G,
+enum physical_alloc_flags {
+  PHYSICAL_ALLOC_DEFAULT = 0,
+  PHYSICAL_ALLOC_BELOW_4G = (1 << 0),
 };
 
 /**
@@ -29,7 +29,7 @@ void mm_init_physical(struct devicetree_node *devicetree);
  *
  * Returns whether it succeeded.
  */
-bool mm_alloc_physical(paddr *out, enum paging_flags f);
+bool mm_alloc_physical(paddr *out, enum physical_alloc_flags flags);
 
 /**
  * Frees a single frame of memory.

--- a/src/kernel/include/mm/physical_alloc.h
+++ b/src/kernel/include/mm/physical_alloc.h
@@ -10,6 +10,14 @@
 #include <devicetree.h>
 
 /**
+ * The possible flags to pass to the allocator
+ */
+enum flags {
+  must_be_below_4g,
+  above_4g_ok,
+};
+
+/**
  * Initializes the physical allocator with the memory discovered in the
  * Devicetree, ignoring memory reservations.
  */
@@ -21,7 +29,7 @@ void mm_init_physical(struct devicetree_node *devicetree);
  *
  * Returns whether it succeeded.
  */
-bool mm_alloc_physical(paddr *out);
+bool mm_alloc_physical(paddr *out, enum flags f);
 
 /**
  * Frees a single frame of memory.

--- a/src/kernel/include/mm/physical_alloc.h
+++ b/src/kernel/include/mm/physical_alloc.h
@@ -12,9 +12,9 @@
 /**
  * The possible flags to pass to the allocator
  */
-enum flags {
-  must_be_below_4g,
-  above_4g_ok,
+enum paging_flags {
+  PAGING_DEFAULT,
+  PAGING_BELOW_4G,
 };
 
 /**
@@ -29,7 +29,7 @@ void mm_init_physical(struct devicetree_node *devicetree);
  *
  * Returns whether it succeeded.
  */
-bool mm_alloc_physical(paddr *out, enum flags f);
+bool mm_alloc_physical(paddr *out, enum paging_flags f);
 
 /**
  * Frees a single frame of memory.

--- a/src/kernel/mm/alloc/segment.c
+++ b/src/kernel/mm/alloc/segment.c
@@ -33,7 +33,7 @@ struct mm_alloc_segment *segment_alloc(usize size) {
   usize va = segment_start;
   paddr pa;
   while (va < segment_end) {
-    if (!mm_alloc_physical(&pa, PAGING_DEFAULT))
+    if (!mm_alloc_physical(&pa, PHYSICAL_ALLOC_DEFAULT))
       goto physical_oom;
     if (!mm_paging_map(va, pa, PGPERM_KRW)) {
       mm_free_physical(pa);

--- a/src/kernel/mm/alloc/segment.c
+++ b/src/kernel/mm/alloc/segment.c
@@ -33,7 +33,7 @@ struct mm_alloc_segment *segment_alloc(usize size) {
   usize va = segment_start;
   paddr pa;
   while (va < segment_end) {
-    if (!mm_alloc_physical(&pa))
+    if (!mm_alloc_physical(&pa, above_4g_ok))
       goto physical_oom;
     if (!mm_paging_map(va, pa, PGPERM_KRW)) {
       mm_free_physical(pa);

--- a/src/kernel/mm/alloc/segment.c
+++ b/src/kernel/mm/alloc/segment.c
@@ -7,6 +7,7 @@
 #include "segment.h"
 #include "heap.h"
 #include <align.h>
+#include <arch/riscv64/constants.h>
 #include <hart_locals.h>
 #include <mm/paging.h>
 #include <mm/physical_alloc.h>

--- a/src/kernel/mm/alloc/segment.c
+++ b/src/kernel/mm/alloc/segment.c
@@ -33,7 +33,7 @@ struct mm_alloc_segment *segment_alloc(usize size) {
   usize va = segment_start;
   paddr pa;
   while (va < segment_end) {
-    if (!mm_alloc_physical(&pa, above_4g_ok))
+    if (!mm_alloc_physical(&pa, PAGING_DEFAULT))
       goto physical_oom;
     if (!mm_paging_map(va, pa, PGPERM_KRW)) {
       mm_free_physical(pa);

--- a/src/kernel/mm/alloc/segment.h
+++ b/src/kernel/mm/alloc/segment.h
@@ -9,6 +9,7 @@
 
 #include "page.h"
 #include "size_classes.h"
+#include <arch/riscv64/constants.h>
 
 struct mm_alloc_heap;
 
@@ -48,7 +49,7 @@ struct mm_alloc_segment {
   struct mm_alloc_page pages[64];
 };
 
-static_assert(sizeof(struct mm_alloc_segment) <= (1 << 12));
+static_assert(sizeof(struct mm_alloc_segment) <= PAGE_SIZE);
 static_assert(alignof(struct mm_alloc_segment) <= (1 << SEGMENT_SHIFT));
 
 /**

--- a/src/kernel/mm/physical_alloc.c
+++ b/src/kernel/mm/physical_alloc.c
@@ -26,13 +26,14 @@ struct physical_free_list {
 static paddr free_list_head_above_4g = {0};
 static paddr free_list_head_below_4g = {0};
 
-static void physical_free_list_push(usize length, paddr start, paddr free_list_head) {
-      struct physical_free_list link = {
-	  .next = free_list_head,
-	  .length = length,
-      };
-      copy_to_physical(start, &link, sizeof(struct physical_free_list));
-      free_list_head = start;
+static void physical_free_list_push(usize length, paddr start,
+                                    paddr free_list_head) {
+  struct physical_free_list link = {
+      .next = free_list_head,
+      .length = length,
+  };
+  copy_to_physical(start, &link, sizeof(struct physical_free_list));
+  free_list_head = start;
 }
 
 static bool physical_free_list_pop(paddr *out, paddr free_list_head) {
@@ -71,16 +72,21 @@ static void add_physical_chunk(paddr start, paddr end) {
   // TODO: The rest of this should have a lock around it.
   print("Found usable physical memory: {paddr}-{paddr}", start, end);
   if (bits_of_paddr(start) >= (1ul << 32)) {
-      physical_free_list_push(paddr_diff(end, start) >> 12, start, free_list_head_above_4g);
-  } else if (bits_of_paddr(start) < (1ul << 32) && bits_of_paddr(end) >= (1ul << 32)) {
-      paddr old_end = end;
-      end = paddr_of_bits(1ul << 32);
-      physical_free_list_push(paddr_diff(end, start) >> 12, start, free_list_head_below_4g);
-      start = end;
-      end = old_end;
-      physical_free_list_push(paddr_diff(end, start) >> 12, start, free_list_head_above_4g);
+    physical_free_list_push(paddr_diff(end, start) >> 12, start,
+                            free_list_head_above_4g);
+  } else if (bits_of_paddr(start) < (1ul << 32) &&
+             bits_of_paddr(end) >= (1ul << 32)) {
+    paddr old_end = end;
+    end = paddr_of_bits(1ul << 32);
+    physical_free_list_push(paddr_diff(end, start) >> 12, start,
+                            free_list_head_below_4g);
+    start = end;
+    end = old_end;
+    physical_free_list_push(paddr_diff(end, start) >> 12, start,
+                            free_list_head_above_4g);
   } else {
-      physical_free_list_push(paddr_diff(end, start) >> 12, start, free_list_head_below_4g);
+    physical_free_list_push(paddr_diff(end, start) >> 12, start,
+                            free_list_head_below_4g);
   }
 }
 

--- a/src/kernel/mm/physical_alloc.c
+++ b/src/kernel/mm/physical_alloc.c
@@ -13,6 +13,7 @@
 /**
  * The physical memory allocator. This is a simple free list allocator.
  */
+
 struct physical_free_list {
   paddr next;
   // The length of the chunk in pages, including the page containing this link.

--- a/src/kernel/mm/physical_alloc.c
+++ b/src/kernel/mm/physical_alloc.c
@@ -209,64 +209,36 @@ void mm_init_physical(struct devicetree_node *devicetree) {
   free(reservations);
 }
 
+bool mm_alloc_physical_helper(paddr *out, paddr free_list_head) {
+  // TODO: There should be a lock around essentially this whole function.
+  *out = free_list_head;
+  if (!bits_of_paddr(*out))
+    return false;
+
+  struct physical_free_list link;
+  copy_from_physical(&link, free_list_head, sizeof(struct physical_free_list));
+  assert(link.length > 0);
+  if (link.length == 1) {
+    // This is the only page in the link, so update the head pointer to point
+    // at the next link.
+    free_list_head = link.next;
+  } else {
+    // There were multiple pages in the link. We'll use the first one, so we
+    // write back the link to the next one.
+    free_list_head = paddr_offset(free_list_head, 1 << 12);
+    link.length--;
+    copy_to_physical(free_list_head, &link, sizeof(struct physical_free_list));
+  }
+  return true;
+}
+
 bool mm_alloc_physical(paddr *out, enum paging_flags f) {
   // TODO: There should be a lock around essentially this whole function.
-  struct physical_free_list link;
 
   if (f != PAGING_BELOW_4G) {
-    if (!bits_of_paddr(free_list_head_above_4g)) {
-        *out = free_list_head_above_4g;
-    } else {
-        *out = free_list_head_below_4g;
-    }
-    if (!bits_of_paddr(*out))
-      return false;
-
-    if (!bits_of_paddr(free_list_head_above_4g)) {
-      copy_from_physical(&link, free_list_head_above_4g, sizeof(struct physical_free_list));
-    } else {
-      copy_from_physical(&link, free_list_head_below_4g, sizeof(struct physical_free_list));
-    }
-    assert(link.length > 0);
-    if (link.length == 1) {
-      // This is the only page in the link, so update the head pointer to point
-      // at the next link.
-      if (!bits_of_paddr(free_list_head_above_4g)) {
-        free_list_head_above_4g = link.next;
-      } else {
-        free_list_head_below_4g = link.next;
-      }
-    } else {
-      // There were multiple pages in the link. We'll use the first one, so we
-      // write back the link to the next one.
-      if (!bits_of_paddr(free_list_head_above_4g)) {
-        free_list_head_above_4g = paddr_offset(free_list_head_above_4g, 1 << 12);
-      } else {
-        free_list_head_below_4g = paddr_offset(free_list_head_below_4g, 1 << 12);
-      }
-      link.length--;
-      if (!bits_of_paddr(free_list_head_above_4g)) {
-        copy_to_physical(free_list_head_above_4g, &link, sizeof(struct physical_free_list));
-      } else {
-        copy_to_physical(free_list_head_below_4g, &link, sizeof(struct physical_free_list));
-      }
-    }
-    return true;
+    return mm_alloc_physical_helper(out, free_list_head_above_4g);
   } else {
-    *out = free_list_head_below_4g;
-    if (!bits_of_paddr(*out))
-      return false;
-
-    copy_from_physical(&link, free_list_head_below_4g, sizeof(struct physical_free_list));
-    assert(link.length > 0);
-    if (link.length == 1) {
-      free_list_head_below_4g = link.next;
-    } else {
-      free_list_head_below_4g = paddr_offset(free_list_head_below_4g, 1 << 12);
-      link.length--;
-      copy_to_physical(free_list_head_above_4g, &link, sizeof(struct physical_free_list));
-    }
-    return true;
+    return mm_alloc_physical_helper(out, free_list_head_below_4g);
   }
 }
 

--- a/src/kernel/mm/physical_alloc.c
+++ b/src/kernel/mm/physical_alloc.c
@@ -36,7 +36,6 @@ static void physical_free_list_push(usize length, paddr start, paddr free_list_h
 }
 
 static bool physical_free_list_pop(paddr *out, paddr free_list_head) {
-  // TODO: There should be a lock around essentially this whole function.
   *out = free_list_head;
   if (!bits_of_paddr(*out))
     return false;

--- a/src/kernel/mm/physical_alloc.c
+++ b/src/kernel/mm/physical_alloc.c
@@ -242,7 +242,7 @@ void mm_init_physical(struct devicetree_node *devicetree) {
 bool mm_alloc_physical(paddr *out, enum physical_alloc_flags flags) {
   // TODO: There should be a lock around essentially this whole function.
 
-  if (flags != PHYSICAL_ALLOC_BELOW_4G) {
+  if (!(flags & PHYSICAL_ALLOC_BELOW_4G)) {
     return physical_free_list_pop(out, free_list_head_above_4g);
   } else {
     return physical_free_list_pop(out, free_list_head_below_4g);

--- a/src/kernel/mm/physical_alloc.c
+++ b/src/kernel/mm/physical_alloc.c
@@ -253,7 +253,7 @@ void mm_free_physical(paddr frame) {
   // TODO: There should be a lock around essentially this whole function.
   assert(bits_of_paddr(frame));
 
-  if (bits_of_paddr(frame) > (1ul << 32)) {
+  if (bits_of_paddr(frame) >= (1ul << 32)) {
     physical_free_list_push(1, frame, free_list_head_above_4g);
   } else {
     physical_free_list_push(1, frame, free_list_head_below_4g);

--- a/src/kernel/mm/physical_alloc.c
+++ b/src/kernel/mm/physical_alloc.c
@@ -13,7 +13,6 @@
 /**
  * The physical memory allocator. This is a simple free list allocator.
  */
-
 struct physical_free_list {
   paddr next;
   // The length of the chunk in pages, including the page containing this link.
@@ -23,7 +22,8 @@ struct physical_free_list {
 /**
  * The head of the free list.
  */
-static paddr free_list_head = {0};
+static paddr free_list_head_above_4g = {0};
+static paddr free_list_head_below_4g = {0};
 
 static void add_physical_chunk(paddr start, paddr end) {
   // Align up the start address and align down the end address, to page
@@ -38,12 +38,33 @@ static void add_physical_chunk(paddr start, paddr end) {
   // Otherwise, write a link header to it.
   // TODO: The rest of this should have a lock around it.
   print("Found usable physical memory: {paddr}-{paddr}", start, end);
-  struct physical_free_list link = {
-      .next = free_list_head,
-      .length = paddr_diff(end, start) >> 12,
-  };
-  copy_to_physical(start, &link, sizeof(struct physical_free_list));
-  free_list_head = start;
+  if (bits_of_paddr(start) > 4294967296) {
+      struct physical_free_list link = {
+	  .next = free_list_head_above_4g,
+	  .length = paddr_diff(end, start) >> 12,
+      };
+      copy_to_physical(start, &link, sizeof(struct physical_free_list));
+      free_list_head_above_4g = start;
+  } else if (bits_of_paddr(start) < 4294967296 && bits_of_paddr(end) > 4294967296) {
+      paddr old_end = end;
+      end = paddr_of_bits(4294967296 - bits_of_paddr(end));
+      struct physical_free_list link = {
+	  .next = free_list_head_below_4g,
+	  .length = paddr_diff(end, start) >> 12,
+      };
+      copy_to_physical(start, &link, sizeof(struct physical_free_list));
+      free_list_head_below_4g = start;
+      start = end;
+      end = old_end;
+      add_physical_chunk(start, end);
+  } else {
+      struct physical_free_list link = {
+	  .next = free_list_head_below_4g,
+	  .length = paddr_diff(end, start) >> 12,
+      };
+      copy_to_physical(start, &link, sizeof(struct physical_free_list));
+      free_list_head_below_4g = start;
+  }
 }
 
 /**
@@ -194,37 +215,84 @@ void mm_init_physical(struct devicetree_node *devicetree) {
   free(reservations);
 }
 
-bool mm_alloc_physical(paddr *out) {
+bool mm_alloc_physical(paddr *out, enum flags f) {
   // TODO: There should be a lock around essentially this whole function.
-  *out = free_list_head;
-  if (!bits_of_paddr(*out))
-    return false;
-
   struct physical_free_list link;
-  copy_from_physical(&link, free_list_head, sizeof(struct physical_free_list));
-  assert(link.length > 0);
-  if (link.length == 1) {
-    // This is the only page in the link, so update the head pointer to point
-    // at the next link.
-    free_list_head = link.next;
+
+  if (f != must_be_below_4g) {
+    if (!bits_of_paddr(free_list_head_above_4g)) {
+        *out = free_list_head_above_4g;
+    } else {
+        *out = free_list_head_below_4g;
+    }
+    if (!bits_of_paddr(*out))
+      return false;
+
+    if (!bits_of_paddr(free_list_head_above_4g)) {
+      copy_from_physical(&link, free_list_head_above_4g, sizeof(struct physical_free_list));
+    } else {
+      copy_from_physical(&link, free_list_head_below_4g, sizeof(struct physical_free_list));
+    }
+    assert(link.length > 0);
+    if (link.length == 1) {
+      // This is the only page in the link, so update the head pointer to point
+      // at the next link.
+      if (!bits_of_paddr(free_list_head_above_4g)) {
+        free_list_head_above_4g = link.next;
+      } else {
+        free_list_head_below_4g = link.next;
+      }
+    } else {
+      // There were multiple pages in the link. We'll use the first one, so we
+      // write back the link to the next one.
+      if (!bits_of_paddr(free_list_head_above_4g)) {
+        free_list_head_above_4g = paddr_offset(free_list_head_above_4g, 1 << 12);
+      } else {
+        free_list_head_below_4g = paddr_offset(free_list_head_below_4g, 1 << 12);
+      }
+      link.length--;
+      if (!bits_of_paddr(free_list_head_above_4g)) {
+        copy_to_physical(free_list_head_above_4g, &link, sizeof(struct physical_free_list));
+      } else {
+        copy_to_physical(free_list_head_below_4g, &link, sizeof(struct physical_free_list));
+      }
+    }
+    return true;
   } else {
-    // There were multiple pages in the link. We'll use the first one, so we
-    // write back the link to the next one.
-    free_list_head = paddr_offset(free_list_head, 1 << 12);
-    link.length--;
-    copy_to_physical(free_list_head, &link, sizeof(struct physical_free_list));
+    *out = free_list_head_below_4g;
+    if (!bits_of_paddr(*out))
+      return false;
+
+    copy_from_physical(&link, free_list_head_below_4g, sizeof(struct physical_free_list));
+    assert(link.length > 0);
+    if (link.length == 1) {
+      free_list_head_below_4g = link.next;
+    } else {
+      free_list_head_below_4g = paddr_offset(free_list_head_below_4g, 1 << 12);
+      link.length--;
+      copy_to_physical(free_list_head_above_4g, &link, sizeof(struct physical_free_list));
+    }
+    return true;
   }
-  return true;
 }
 
 void mm_free_physical(paddr frame) {
   // TODO: There should be a lock around essentially this whole function.
   assert(bits_of_paddr(frame));
 
-  struct physical_free_list link = {
-      .next = free_list_head,
-      .length = 1,
-  };
-  copy_to_physical(frame, &link, sizeof(struct physical_free_list));
-  free_list_head = frame;
+  if (bits_of_paddr(frame) > 4294967296) {
+    struct physical_free_list link = {
+        .next = free_list_head_above_4g,
+        .length = 1,
+    };
+    copy_to_physical(frame, &link, sizeof(struct physical_free_list));
+    free_list_head_above_4g = frame;
+  } else {
+    struct physical_free_list link = {
+        .next = free_list_head_below_4g,
+        .length = 1,
+    };
+    copy_to_physical(frame, &link, sizeof(struct physical_free_list));
+    free_list_head_below_4g = frame;
+  }
 }

--- a/src/kernel/mm/physical_alloc.c
+++ b/src/kernel/mm/physical_alloc.c
@@ -38,16 +38,16 @@ static void add_physical_chunk(paddr start, paddr end) {
   // Otherwise, write a link header to it.
   // TODO: The rest of this should have a lock around it.
   print("Found usable physical memory: {paddr}-{paddr}", start, end);
-  if (bits_of_paddr(start) > 4294967296) {
+  if (bits_of_paddr(start) > 0x100000000) {
       struct physical_free_list link = {
 	  .next = free_list_head_above_4g,
 	  .length = paddr_diff(end, start) >> 12,
       };
       copy_to_physical(start, &link, sizeof(struct physical_free_list));
       free_list_head_above_4g = start;
-  } else if (bits_of_paddr(start) < 4294967296 && bits_of_paddr(end) > 4294967296) {
+  } else if (bits_of_paddr(start) < 0x100000000 && bits_of_paddr(end) > 0x100000000) {
       paddr old_end = end;
-      end = paddr_of_bits(4294967296 - bits_of_paddr(end));
+      end = paddr_of_bits(0x100000000 - bits_of_paddr(end));
       struct physical_free_list link = {
 	  .next = free_list_head_below_4g,
 	  .length = paddr_diff(end, start) >> 12,
@@ -280,7 +280,7 @@ void mm_free_physical(paddr frame) {
   // TODO: There should be a lock around essentially this whole function.
   assert(bits_of_paddr(frame));
 
-  if (bits_of_paddr(frame) > 4294967296) {
+  if (bits_of_paddr(frame) > 0x100000000) {
     struct physical_free_list link = {
         .next = free_list_head_above_4g,
         .length = 1,

--- a/src/kernel/mm/physical_alloc.c
+++ b/src/kernel/mm/physical_alloc.c
@@ -25,7 +25,7 @@ struct physical_free_list {
 static paddr free_list_head_above_4g = {0};
 static paddr free_list_head_below_4g = {0};
 
-static void add_physical_chunk_helper(usize length, paddr start, paddr free_list_head) {
+static void physical_free_list_push(usize length, paddr start, paddr free_list_head) {
       struct physical_free_list link = {
 	  .next = free_list_head,
 	  .length = length,
@@ -47,11 +47,11 @@ static void add_physical_chunk(paddr start, paddr end) {
   // Otherwise, write a link header to it.
   // TODO: The rest of this should have a lock around it.
   print("Found usable physical memory: {paddr}-{paddr}", start, end);
-  if (bits_of_paddr(start) >= 0x100000000) {
+  if (bits_of_paddr(start) >= (1 << 32)) {
       add_physical_chunk_helper(paddr_diff(end, start) >> 12, start, free_list_head_above_4g);
   } else if (bits_of_paddr(start) < 0x100000000 && bits_of_paddr(end) >= 0x100000000) {
       paddr old_end = end;
-      end = paddr_of_bits(0x100000000 - bits_of_paddr(end));
+      end = paddr_of_bits(1 << 32);
       add_physical_chunk_helper(paddr_diff(end, start) >> 12, start, free_list_head_below_4g);
       start = end;
       end = old_end;
@@ -232,10 +232,10 @@ bool mm_alloc_physical_helper(paddr *out, paddr free_list_head) {
   return true;
 }
 
-bool mm_alloc_physical(paddr *out, enum paging_flags f) {
+bool mm_alloc_physical(paddr *out, enum physical_alloc_flags flags) {
   // TODO: There should be a lock around essentially this whole function.
 
-  if (f != PAGING_BELOW_4G) {
+  if (flags != PAGING_BELOW_4G) {
     return mm_alloc_physical_helper(out, free_list_head_above_4g);
   } else {
     return mm_alloc_physical_helper(out, free_list_head_below_4g);

--- a/src/kernel/mm/physical_alloc.c
+++ b/src/kernel/mm/physical_alloc.c
@@ -35,7 +35,7 @@ static void physical_free_list_push(usize length, paddr start, paddr free_list_h
       free_list_head = start;
 }
 
-bool physical_free_list_pop(paddr *out, paddr free_list_head) {
+static bool physical_free_list_pop(paddr *out, paddr free_list_head) {
   // TODO: There should be a lock around essentially this whole function.
   *out = free_list_head;
   if (!bits_of_paddr(*out))

--- a/src/kernel/mm/physical_alloc.c
+++ b/src/kernel/mm/physical_alloc.c
@@ -215,11 +215,11 @@ void mm_init_physical(struct devicetree_node *devicetree) {
   free(reservations);
 }
 
-bool mm_alloc_physical(paddr *out, enum flags f) {
+bool mm_alloc_physical(paddr *out, enum paging_flags f) {
   // TODO: There should be a lock around essentially this whole function.
   struct physical_free_list link;
 
-  if (f != must_be_below_4g) {
+  if (f != PAGING_BELOW_4G) {
     if (!bits_of_paddr(free_list_head_above_4g)) {
         *out = free_list_head_above_4g;
     } else {

--- a/src/kernel/mm/physical_alloc.c
+++ b/src/kernel/mm/physical_alloc.c
@@ -38,14 +38,14 @@ static void add_physical_chunk(paddr start, paddr end) {
   // Otherwise, write a link header to it.
   // TODO: The rest of this should have a lock around it.
   print("Found usable physical memory: {paddr}-{paddr}", start, end);
-  if (bits_of_paddr(start) > 0x100000000) {
+  if (bits_of_paddr(start) >= 0x100000000) {
       struct physical_free_list link = {
 	  .next = free_list_head_above_4g,
 	  .length = paddr_diff(end, start) >> 12,
       };
       copy_to_physical(start, &link, sizeof(struct physical_free_list));
       free_list_head_above_4g = start;
-  } else if (bits_of_paddr(start) < 0x100000000 && bits_of_paddr(end) > 0x100000000) {
+  } else if (bits_of_paddr(start) < 0x100000000 && bits_of_paddr(end) >= 0x100000000) {
       paddr old_end = end;
       end = paddr_of_bits(0x100000000 - bits_of_paddr(end));
       struct physical_free_list link = {

--- a/src/kernel/mm/physical_alloc.c
+++ b/src/kernel/mm/physical_alloc.c
@@ -5,6 +5,7 @@
  */
 
 #include <align.h>
+#include <arch/riscv64/constants.h>
 #include <devicetree.h>
 #include <mm/physical_alloc.h>
 #include <physical.h>
@@ -51,7 +52,7 @@ static bool physical_free_list_pop(paddr *out, paddr free_list_head) {
   } else {
     // There were multiple pages in the link. We'll use the first one, so we
     // write back the link to the next one.
-    free_list_head = paddr_offset(free_list_head, 1 << 12);
+    free_list_head = paddr_offset(free_list_head, PAGE_SIZE);
     link.length--;
     copy_to_physical(free_list_head, &link, sizeof(struct physical_free_list));
   }

--- a/src/kernel/mm/physical_alloc.c
+++ b/src/kernel/mm/physical_alloc.c
@@ -242,13 +242,9 @@ void mm_init_physical(struct devicetree_node *devicetree) {
 bool mm_alloc_physical(paddr *out, enum physical_alloc_flags flags) {
   // TODO: There should be a lock around essentially this whole function.
 
-  if (!(flags & PHYSICAL_ALLOC_BELOW_4G)) {
-    return physical_free_list_pop(out, free_list_head_above_4g);
-  } else {
-    return physical_free_list_pop(out, free_list_head_below_4g);
-  if (!(flags & PHYSICAL_ALLOC_BELOW_4G)
-    && physical_free_list_pop(out, free_list_head_above_4g))
-      return true;
+  if (!(flags & PHYSICAL_ALLOC_BELOW_4G) &&
+      physical_free_list_pop(out, free_list_head_above_4g))
+    return true;
 
   return physical_free_list_pop(out, free_list_head_below_4g);
 }

--- a/src/kernel/mm/physical_alloc.c
+++ b/src/kernel/mm/physical_alloc.c
@@ -25,6 +25,15 @@ struct physical_free_list {
 static paddr free_list_head_above_4g = {0};
 static paddr free_list_head_below_4g = {0};
 
+static void add_physical_chunk_helper(paddr start, paddr end, paddr free_list_head) {
+      struct physical_free_list link = {
+	  .next = free_list_head,
+	  .length = paddr_diff(end, start) >> 12,
+      };
+      copy_to_physical(start, &link, sizeof(struct physical_free_list));
+      free_list_head = start;
+}
+
 static void add_physical_chunk(paddr start, paddr end) {
   // Align up the start address and align down the end address, to page
   // boundaries.
@@ -39,31 +48,16 @@ static void add_physical_chunk(paddr start, paddr end) {
   // TODO: The rest of this should have a lock around it.
   print("Found usable physical memory: {paddr}-{paddr}", start, end);
   if (bits_of_paddr(start) >= 0x100000000) {
-      struct physical_free_list link = {
-	  .next = free_list_head_above_4g,
-	  .length = paddr_diff(end, start) >> 12,
-      };
-      copy_to_physical(start, &link, sizeof(struct physical_free_list));
-      free_list_head_above_4g = start;
+      add_physical_chunk_helper(start, end, free_list_head_above_4g);
   } else if (bits_of_paddr(start) < 0x100000000 && bits_of_paddr(end) >= 0x100000000) {
       paddr old_end = end;
       end = paddr_of_bits(0x100000000 - bits_of_paddr(end));
-      struct physical_free_list link = {
-	  .next = free_list_head_below_4g,
-	  .length = paddr_diff(end, start) >> 12,
-      };
-      copy_to_physical(start, &link, sizeof(struct physical_free_list));
-      free_list_head_below_4g = start;
+      add_physical_chunk_helper(start, end, free_list_head_below_4g);
       start = end;
       end = old_end;
-      add_physical_chunk(start, end);
+      add_physical_chunk_helper(start, end, free_list_head_above_4g);
   } else {
-      struct physical_free_list link = {
-	  .next = free_list_head_below_4g,
-	  .length = paddr_diff(end, start) >> 12,
-      };
-      copy_to_physical(start, &link, sizeof(struct physical_free_list));
-      free_list_head_below_4g = start;
+      add_physical_chunk_helper(start, end, free_list_head_below_4g);
   }
 }
 

--- a/src/kernel/mm/physical_alloc.c
+++ b/src/kernel/mm/physical_alloc.c
@@ -25,7 +25,7 @@ struct physical_free_list {
 static paddr free_list_head_above_4g = {0};
 static paddr free_list_head_below_4g = {0};
 
-static void add_physical_chunk_helper(paddr length, paddr free_list_head) {
+static void add_physical_chunk_helper(usize length, paddr start, paddr free_list_head) {
       struct physical_free_list link = {
 	  .next = free_list_head,
 	  .length = length,
@@ -48,16 +48,16 @@ static void add_physical_chunk(paddr start, paddr end) {
   // TODO: The rest of this should have a lock around it.
   print("Found usable physical memory: {paddr}-{paddr}", start, end);
   if (bits_of_paddr(start) >= 0x100000000) {
-      add_physical_chunk_helper(start, end, free_list_head_above_4g);
+      add_physical_chunk_helper(paddr_diff(end, start) >> 12, start, free_list_head_above_4g);
   } else if (bits_of_paddr(start) < 0x100000000 && bits_of_paddr(end) >= 0x100000000) {
       paddr old_end = end;
       end = paddr_of_bits(0x100000000 - bits_of_paddr(end));
-      add_physical_chunk_helper(paddr_diff(end, start) >> 12, free_list_head_below_4g);
+      add_physical_chunk_helper(paddr_diff(end, start) >> 12, start, free_list_head_below_4g);
       start = end;
       end = old_end;
-      add_physical_chunk_helper(paddr_diff(end, start) >> 12, free_list_head_above_4g);
+      add_physical_chunk_helper(paddr_diff(end, start) >> 12, start, free_list_head_above_4g);
   } else {
-      add_physical_chunk_helper(paddr_diff(end, start) >> 12, free_list_head_below_4g);
+      add_physical_chunk_helper(paddr_diff(end, start) >> 12, start, free_list_head_below_4g);
   }
 }
 
@@ -275,8 +275,8 @@ void mm_free_physical(paddr frame) {
   assert(bits_of_paddr(frame));
 
   if (bits_of_paddr(frame) > 0x100000000) {
-    add_physical_chunk_helper(1, free_list_above_4g);
+    add_physical_chunk_helper(1, frame, free_list_head_above_4g);
   } else {
-    add_physical_chunk_helper(1, free_list_below_4g);
+    add_physical_chunk_helper(1, frame, free_list_head_below_4g);
   }
 }

--- a/src/kernel/mm/physical_alloc.c
+++ b/src/kernel/mm/physical_alloc.c
@@ -275,18 +275,8 @@ void mm_free_physical(paddr frame) {
   assert(bits_of_paddr(frame));
 
   if (bits_of_paddr(frame) > 0x100000000) {
-    struct physical_free_list link = {
-        .next = free_list_head_above_4g,
-        .length = 1,
-    };
-    copy_to_physical(frame, &link, sizeof(struct physical_free_list));
-    free_list_head_above_4g = frame;
+    add_physical_chunk_helper(1, free_list_above_4g);
   } else {
-    struct physical_free_list link = {
-        .next = free_list_head_below_4g,
-        .length = 1,
-    };
-    copy_to_physical(frame, &link, sizeof(struct physical_free_list));
-    free_list_head_below_4g = frame;
+    add_physical_chunk_helper(1, free_list_below_4g);
   }
 }

--- a/src/kernel/mm/physical_alloc.c
+++ b/src/kernel/mm/physical_alloc.c
@@ -246,7 +246,11 @@ bool mm_alloc_physical(paddr *out, enum physical_alloc_flags flags) {
     return physical_free_list_pop(out, free_list_head_above_4g);
   } else {
     return physical_free_list_pop(out, free_list_head_below_4g);
-  }
+  if (!(flags & PHYSICAL_ALLOC_BELOW_4G)
+    && physical_free_list_pop(out, free_list_head_above_4g))
+      return true;
+
+  return physical_free_list_pop(out, free_list_head_below_4g);
 }
 
 void mm_free_physical(paddr frame) {

--- a/src/kernel/mm/physical_alloc.c
+++ b/src/kernel/mm/physical_alloc.c
@@ -25,10 +25,10 @@ struct physical_free_list {
 static paddr free_list_head_above_4g = {0};
 static paddr free_list_head_below_4g = {0};
 
-static void add_physical_chunk_helper(paddr start, paddr end, paddr free_list_head) {
+static void add_physical_chunk_helper(paddr length, paddr free_list_head) {
       struct physical_free_list link = {
 	  .next = free_list_head,
-	  .length = paddr_diff(end, start) >> 12,
+	  .length = length,
       };
       copy_to_physical(start, &link, sizeof(struct physical_free_list));
       free_list_head = start;
@@ -52,12 +52,12 @@ static void add_physical_chunk(paddr start, paddr end) {
   } else if (bits_of_paddr(start) < 0x100000000 && bits_of_paddr(end) >= 0x100000000) {
       paddr old_end = end;
       end = paddr_of_bits(0x100000000 - bits_of_paddr(end));
-      add_physical_chunk_helper(start, end, free_list_head_below_4g);
+      add_physical_chunk_helper(paddr_diff(end, start) >> 12, free_list_head_below_4g);
       start = end;
       end = old_end;
-      add_physical_chunk_helper(start, end, free_list_head_above_4g);
+      add_physical_chunk_helper(paddr_diff(end, start) >> 12, free_list_head_above_4g);
   } else {
-      add_physical_chunk_helper(start, end, free_list_head_below_4g);
+      add_physical_chunk_helper(paddr_diff(end, start) >> 12, free_list_head_below_4g);
   }
 }
 

--- a/src/kernel/mm/physical_alloc.c
+++ b/src/kernel/mm/physical_alloc.c
@@ -34,6 +34,29 @@ static void physical_free_list_push(usize length, paddr start, paddr free_list_h
       free_list_head = start;
 }
 
+bool physical_free_list_pop(paddr *out, paddr free_list_head) {
+  // TODO: There should be a lock around essentially this whole function.
+  *out = free_list_head;
+  if (!bits_of_paddr(*out))
+    return false;
+
+  struct physical_free_list link;
+  copy_from_physical(&link, free_list_head, sizeof(struct physical_free_list));
+  assert(link.length > 0);
+  if (link.length == 1) {
+    // This is the only page in the link, so update the head pointer to point
+    // at the next link.
+    free_list_head = link.next;
+  } else {
+    // There were multiple pages in the link. We'll use the first one, so we
+    // write back the link to the next one.
+    free_list_head = paddr_offset(free_list_head, 1 << 12);
+    link.length--;
+    copy_to_physical(free_list_head, &link, sizeof(struct physical_free_list));
+  }
+  return true;
+}
+
 static void add_physical_chunk(paddr start, paddr end) {
   // Align up the start address and align down the end address, to page
   // boundaries.
@@ -47,17 +70,17 @@ static void add_physical_chunk(paddr start, paddr end) {
   // Otherwise, write a link header to it.
   // TODO: The rest of this should have a lock around it.
   print("Found usable physical memory: {paddr}-{paddr}", start, end);
-  if (bits_of_paddr(start) >= (1 << 32)) {
-      add_physical_chunk_helper(paddr_diff(end, start) >> 12, start, free_list_head_above_4g);
-  } else if (bits_of_paddr(start) < 0x100000000 && bits_of_paddr(end) >= 0x100000000) {
+  if (bits_of_paddr(start) >= (1ul << 32)) {
+      physical_free_list_push(paddr_diff(end, start) >> 12, start, free_list_head_above_4g);
+  } else if (bits_of_paddr(start) < (1ul << 32) && bits_of_paddr(end) >= (1ul << 32)) {
       paddr old_end = end;
-      end = paddr_of_bits(1 << 32);
-      add_physical_chunk_helper(paddr_diff(end, start) >> 12, start, free_list_head_below_4g);
+      end = paddr_of_bits(1ul << 32);
+      physical_free_list_push(paddr_diff(end, start) >> 12, start, free_list_head_below_4g);
       start = end;
       end = old_end;
-      add_physical_chunk_helper(paddr_diff(end, start) >> 12, start, free_list_head_above_4g);
+      physical_free_list_push(paddr_diff(end, start) >> 12, start, free_list_head_above_4g);
   } else {
-      add_physical_chunk_helper(paddr_diff(end, start) >> 12, start, free_list_head_below_4g);
+      physical_free_list_push(paddr_diff(end, start) >> 12, start, free_list_head_below_4g);
   }
 }
 
@@ -209,36 +232,13 @@ void mm_init_physical(struct devicetree_node *devicetree) {
   free(reservations);
 }
 
-bool mm_alloc_physical_helper(paddr *out, paddr free_list_head) {
-  // TODO: There should be a lock around essentially this whole function.
-  *out = free_list_head;
-  if (!bits_of_paddr(*out))
-    return false;
-
-  struct physical_free_list link;
-  copy_from_physical(&link, free_list_head, sizeof(struct physical_free_list));
-  assert(link.length > 0);
-  if (link.length == 1) {
-    // This is the only page in the link, so update the head pointer to point
-    // at the next link.
-    free_list_head = link.next;
-  } else {
-    // There were multiple pages in the link. We'll use the first one, so we
-    // write back the link to the next one.
-    free_list_head = paddr_offset(free_list_head, 1 << 12);
-    link.length--;
-    copy_to_physical(free_list_head, &link, sizeof(struct physical_free_list));
-  }
-  return true;
-}
-
 bool mm_alloc_physical(paddr *out, enum physical_alloc_flags flags) {
   // TODO: There should be a lock around essentially this whole function.
 
-  if (flags != PAGING_BELOW_4G) {
-    return mm_alloc_physical_helper(out, free_list_head_above_4g);
+  if (flags != PHYSICAL_ALLOC_BELOW_4G) {
+    return physical_free_list_pop(out, free_list_head_above_4g);
   } else {
-    return mm_alloc_physical_helper(out, free_list_head_below_4g);
+    return physical_free_list_pop(out, free_list_head_below_4g);
   }
 }
 
@@ -246,9 +246,9 @@ void mm_free_physical(paddr frame) {
   // TODO: There should be a lock around essentially this whole function.
   assert(bits_of_paddr(frame));
 
-  if (bits_of_paddr(frame) > 0x100000000) {
-    add_physical_chunk_helper(1, frame, free_list_head_above_4g);
+  if (bits_of_paddr(frame) > (1ul << 32)) {
+    physical_free_list_push(1, frame, free_list_head_above_4g);
   } else {
-    add_physical_chunk_helper(1, frame, free_list_head_below_4g);
+    physical_free_list_push(1, frame, free_list_head_below_4g);
   }
 }


### PR DESCRIPTION
context: allows the following to be replaced with a call to malloc: https://github.com/UMN-Kernel-Object/ukoos/pull/81/changes#diff-27c2ba0f80b33f6f149816b6e746f6059adcebfb9bc1b86ad1052b66625b2f2aR61