### PR TITLE
Implement debug assertions

### DIFF
--- a/configure
+++ b/configure
@@ -22,6 +22,8 @@ usage() {
 	printf >&2 '\nDefaults:\n'
 	printf >&2 '  --no-default-cflags     disables default CFLAGS\n'
 	printf >&2 '  --no-default-ldflags    disables default LDFLAGS\n'
+	printf >&2 '\nBuild:\n'
+	printf >&2 '  --debug                 enable debug assertions\n'
 	exit 100
 }
 

--- a/configure
+++ b/configure
@@ -29,13 +29,14 @@ known_arches=(riscv64)
 # shellcheck disable=SC2034 # Only accessed indirectly.
 tool_prefixes_riscv64=(riscv64-none-elf- riscv-none-elf- riscv64-unknown-elf-)
 
-args=$(getopt -n ./configure -o 'h' -l 'arch:,help,no-default-cflags,prefix:,target:' -- "$@")
+args=$(getopt -n ./configure -o 'h' -l 'arch:,debug,help,no-default-cflags,prefix:,target:' -- "$@")
 eval set -- "$args"
 unset args
 
 arch=riscv64
 target=
 has_target=0
+debug=0
 default_cflags=1
 default_ldflags=1
 help=0
@@ -61,6 +62,10 @@ while true; do
 			printf >&2 './configure: unrecognized --arch: %q\n' "$arch"
 			usage
 		fi
+		;;
+	--debug)
+		debug=1
+		shift
 		;;
 	--no-default-cflags)
 		default_cflags=0
@@ -121,6 +126,11 @@ if [[ -e Makefile ]]; then
 else
 	ln -s "$repo/Makefile" Makefile
 fi
+
+if [[ "$debug" = 1 ]]; then
+	CFLAGS="-DDEBUG ${CFLAGS:-}"
+fi
+
 
 # Add default CFLAGS and LDFLAGS.
 if [[ "$default_cflags" = 1 ]]; then

--- a/src/kernel/include/panic.h
+++ b/src/kernel/include/panic.h
@@ -40,4 +40,12 @@ static inline void _assert(const char *file, usize line, const char *func,
 #define TODO(...)                                                              \
   _panic(__FILE__, __LINE__, __func__, "TODO" __VA_OPT__(": ") __VA_ARGS__)
 
+#ifdef DEBUG
+#define debug_assert(cond, ...)                                                \
+  _assert(__FILE__, __LINE__, __func__, cond, #cond,                           \
+          "debug assertion failed" __VA_OPT__(": ") __VA_ARGS__)
+#else
+#define debug_assert(cond, ...)
+#endif // DEBUG
+
 #endif // UKO_OS_KERNEL__PANIC_H

--- a/src/kernel/include/panic.h
+++ b/src/kernel/include/panic.h
@@ -9,6 +9,12 @@
 
 #include <types.h>
 
+#ifdef DEBUG
+constexpr bool debug_asserts_enabled = true;
+#else
+constexpr bool debug_asserts_enabled = false;
+#endif // DEBUG
+
 [[noreturn]]
 void __panic(const char *file, usize line, const char *func, const char *msg,
              va_list ap);
@@ -40,12 +46,8 @@ static inline void _assert(const char *file, usize line, const char *func,
 #define TODO(...)                                                              \
   _panic(__FILE__, __LINE__, __func__, "TODO" __VA_OPT__(": ") __VA_ARGS__)
 
-#ifdef DEBUG
 #define debug_assert(cond, ...)                                                \
-  _assert(__FILE__, __LINE__, __func__, cond, #cond,                           \
-          "debug assertion failed" __VA_OPT__(": ") __VA_ARGS__)
-#else
-#define debug_assert(cond, ...)
-#endif // DEBUG
+  _assert(__FILE__, __LINE__, __func__, debug_asserts_enabled && (cond),       \
+          #cond, "debug assertion failed" __VA_OPT__(": ") __VA_ARGS__)
 
 #endif // UKO_OS_KERNEL__PANIC_H


### PR DESCRIPTION
Adds a `--debug` flag for configure script and a `debug_assert` function. Closes #62.

Questions:
- Lower optimization level for debug profile, or any other compiler/linker flags?