### PR TITLE
Make help target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ result-*
 /src/kernel/arch/riscv64/kernel.elf
 /src/kernel/kernel.elf
 /src/kernel/kernel.sym
+
+cscope.*
+*.swp
+*~

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ watch:
 format:
 	@find $(srcdir) -type f \( -name '*.c' -o -name '*.h' \) \
 		-exec clang-format -i {} \; \
-		-printf "FORMAT  %P\n"
+		-exec echo 'FORMAT {}' \;
 
 .PHONY: all clean install watch format help
 .SUFFIXES:

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,44 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+define HELP_TEXT
+Configuring:
+mkdir build
+cd build
+../configure
+
+Make targets other than "help" require configuration.
+
+Make Targets:
+- (default): Build UkoOS.
+- qemu: Run inside of the QEMU virtual machine.
+- qemu-debug: Run inside of QEMU for debugging. Run make gdb in another
+  terminal to attach.
+- gdb: Attach gdb to a running debug session.
+- clean: Clean build artefacts.
+- watch: Build and rebuild on new changes in doc/ and src/.
+- doc-serve: Serve the UkoOS docs on port 3000, and rebuild on changes.
+- doc: Build HTML documentation.
+- help: Show this help text.
+- format: clang-format source files.
+
+More documentation is available at https://docs.ukoos.org
+endef
+export HELP_TEXT
+
+ifeq ($(strip $(MAKECMDGOALS)),$(strip $(filter help,$(MAKECMDGOALS))))
+ifneq (,$(MAKECMDGOALS))
+help_only = 1
+endif
+endif
+
 # Include config.mak, and make sure that it is present.
+ifndef help_only
 -include config.mak
 ifndef config_mak_present
 $(error The build was not configured; run ./configure)
 endif
+endif # help_only
 
 # Turn off some built-in behavior we don't want.
 .DEFAULT_GOAL = all
@@ -40,6 +73,7 @@ $(1)-ldflags ?=
 endef
 
 # Information about the build to perform.
+ifndef help_only
 include $(srcdir)/doc/include.mak
 include $(srcdir)/src/kernel/include.mak
 
@@ -47,11 +81,15 @@ include $(srcdir)/src/kernel/include.mak
 ifeq ($(realpath $(srcdir)/src/targets/$(arch)/$(target).mak),)
 $(error The target $(target) did not exist; rerun ./configure)
 endif
+
 include $(srcdir)/src/targets/$(arch)/$(target).mak
+endif # help_only
 
 # Common rules.
 all::
 $(call defcleanable,compile_commands.json)
+help:
+	@echo "$$HELP_TEXT"
 distclean: clean
 	@if [[ -e config.mak ]]; then echo "CLEAN   config.mak"; rm config.mak; fi
 	@if [[ -e Makefile ]]; then echo "CLEAN   Makefile"; rm Makefile; fi
@@ -68,7 +106,7 @@ format:
 		-exec clang-format -i {} \; \
 		-printf "FORMAT  %P\n"
 
-.PHONY: all clean install watch format
+.PHONY: all clean install watch format help
 .SUFFIXES:
 
 define common_rules_for_dir


### PR DESCRIPTION
This adds a make help target. If all supplied make targets are `help`,
configuration is not required. This also makes running `make help` by
itself faster, because it won't try to include the other Makefiles.

HELP_TEXT is defined at the top of the Makefile so that it can act
like documentation within the Makefile.

It suggests using `../configure` instead of
`../configure --targets qemu-riscv64` because the configure script will
explain how to list and select targets when run with no arguments.

 This gitignores cscope database files and vim swap files. Since two
members of UKO use cscope it is worth gitignoring, same with vim swap
files. The cscope database can be regenerated from the repository, and
swap files are temporary and should not be version controlled.

It may be worth adding a cscope make target like the linux kernel has.

This fixes the find prints after each file is formatted. The busybox
version of find in our alpine qemu VM does not recongnise -printf.

This should close #38 .

## Merge this before merging #105 .