### PR TITLE
QEMU Time Travel Debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ result-*
 /src/kernel/arch/riscv64/kernel.elf
 /src/kernel/kernel.elf
 /src/kernel/kernel.sym
+
+cscope*
+*.swp

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ watch:
 format:
 	@find $(srcdir) -type f \( -name '*.c' -o -name '*.h' \) \
 		-exec clang-format -i {} \; \
-		-printf "FORMAT  %P\n"
+		-exec echo 'FORMAT {}' \;
 
 .PHONY: all clean install watch format help
 .SUFFIXES:

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ Make Targets:
 - qemu-debug: Run inside of QEMU for debugging. Run make gdb in another
   terminal to attach.
 - gdb: Attach gdb to a running debug session.
+- qemu-record: Record a debug execution.
+- qemu-replay: Replay a recorded debug execution. Equivalent to qemu-debug
+  for time travel debugging. Run make gdb in another terminal to attach.
 - clean: Clean build artefacts.
 - watch: Build and rebuild on new changes in doc/ and src/.
 - doc-serve: Serve the UkoOS docs on port 3000, and rebuild on changes.

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,44 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+define HELP_TEXT
+Configuring:
+mkdir build
+cd build
+../configure
+
+Make targets other than "help" require configuration.
+
+Make Targets:
+- (default): Build UkoOS.
+- qemu: Run inside of the QEMU virtual machine.
+- qemu-debug: Run inside of QEMU for debugging. Run make gdb in another
+  terminal to attach.
+- gdb: Attach gdb to a running debug session.
+- clean: Clean build artefacts.
+- watch: Build and rebuild on new changes in doc/ and src/.
+- doc-serve: Serve the UkoOS docs on port 3000, and rebuild on changes.
+- doc/book: Build HTML documentation.
+- help: Show this help text.
+- format: clang-format source files.
+
+More documentation is available at docs.ukoos.org
+endef
+export HELP_TEXT
+
+ifeq ($(strip $(MAKECMDGOALS)),$(strip $(filter help,$(MAKECMDGOALS))))
+ifneq (,$(MAKECMDGOALS))
+help_only = 1
+endif
+endif
+
 # Include config.mak, and make sure that it is present.
+ifndef help_only
 -include config.mak
 ifndef config_mak_present
 $(error The build was not configured; run ./configure)
 endif
+endif # help_only
 
 # Turn off some built-in behavior we don't want.
 .DEFAULT_GOAL = all
@@ -40,6 +73,7 @@ $(1)-ldflags ?=
 endef
 
 # Information about the build to perform.
+ifndef help_only
 include $(srcdir)/doc/include.mak
 include $(srcdir)/src/kernel/include.mak
 
@@ -47,11 +81,15 @@ include $(srcdir)/src/kernel/include.mak
 ifeq ($(realpath $(srcdir)/src/targets/$(arch)/$(target).mak),)
 $(error The target $(target) did not exist; rerun ./configure)
 endif
+
 include $(srcdir)/src/targets/$(arch)/$(target).mak
+endif # help_only
 
 # Common rules.
 all::
 $(call defcleanable,compile_commands.json)
+help:
+	@echo "$$HELP_TEXT"
 distclean: clean
 	@if [[ -e config.mak ]]; then echo "CLEAN   config.mak"; rm config.mak; fi
 	@if [[ -e Makefile ]]; then echo "CLEAN   Makefile"; rm Makefile; fi
@@ -68,7 +106,7 @@ format:
 		-exec clang-format -i {} \; \
 		-printf "FORMAT  %P\n"
 
-.PHONY: all clean install watch format
+.PHONY: all clean install watch format help
 .SUFFIXES:
 
 define common_rules_for_dir

--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -23,3 +23,4 @@
   - [First Day](./tutorials/first-day.md)
   - [Flashing Duo S](./tutorials/flashing-duo-s.md)
   - [Rebuilding the Dev Container](./tutorials/rebuild-devcontainer.md)
+  - [Time Travel Debugging](./tutorials/time-travel-debug.md)

--- a/doc/tutorials/time-travel-debug.md
+++ b/doc/tutorials/time-travel-debug.md
@@ -1,0 +1,23 @@
+# Time Travel Debugging
+
+UkoOS supports time travel debugging with qemu.
+Time travel debugging allows moving both backwards and forwards when debugging.
+It is only supported on the `qemu-riscv64` target.
+Make sure that target is selected before using time travel debugging.
+
+## Record
+
+Make sure to configure the `qemu-riscv64` like in the [First Day Tutorial](../tutorials/first-day.md).
+
+To record an execution to play back later, use `make qemu-record`.
+Making a recording is required for time travel debugging.
+
+## Replay
+
+Once a recording has been created, `make qemu-replay` is roughly equivalent to
+`make qemu-debug`. Run `make qemu-replay`, then `make gdb` in another
+terminal. The replay should be the same as the execution recorded earlier.
+
+`rc` or `reverse-continue` will find the most recent breakpoint in the past.
+
+`rsi` or `reverse-stepi` will step one instruction back.

--- a/doc/tutorials/time-travel-debug.md
+++ b/doc/tutorials/time-travel-debug.md
@@ -1,6 +1,6 @@
 # Time Travel Debugging
 
-UkoOS supports time travel debugging with qemu.
+ukoOS supports time travel debugging with QEMU.
 Time travel debugging allows moving both backwards and forwards when debugging.
 It is only supported on the `qemu-riscv64` target.
 Make sure that target is selected before using time travel debugging.
@@ -14,9 +14,9 @@ Making a recording is required for time travel debugging.
 
 ## Replay
 
-Once a recording has been created, `make qemu-replay` is roughly equivalent to
-`make qemu-debug`. Run `make qemu-replay`, then `make gdb` in another
-terminal. The replay should be the same as the execution recorded earlier.
+Once a recording has been created, `make qemu-replay` is roughly equivalent to `make qemu-debug`.
+Run `make qemu-replay`, then `make gdb` in another terminal.
+The replay should be the same as the execution recorded earlier.
 
 `rc` or `reverse-continue` will find the most recent breakpoint in the past.
 

--- a/src/kernel/arch/riscv64/include.mak
+++ b/src/kernel/arch/riscv64/include.mak
@@ -68,7 +68,7 @@ qemu-debug: src/kernel/kernel.elf
 		$(QEMUFLAGS)
 qemu-record: src/kernel/kernel.elf
 	touch disk.qcow2
-	export RR=record && \
+	RR=record && \
 	qemu-system-riscv64 \
 		-nographic \
 		-kernel src/kernel/kernel.elf \
@@ -77,7 +77,7 @@ qemu-record: src/kernel/kernel.elf
 
 qemu-replay: src/kernel/kernel.elf
 	touch disk.qcow2
-	export RR=replay && \
+	RR=replay && \
 	qemu-system-riscv64 \
 		-nographic \
 		-kernel src/kernel/kernel.elf \

--- a/src/kernel/arch/riscv64/include.mak
+++ b/src/kernel/arch/riscv64/include.mak
@@ -66,7 +66,26 @@ qemu-debug: src/kernel/kernel.elf
 		-s -S \
 		$(target-qemuflags) \
 		$(QEMUFLAGS)
-.PHONY: gdb gdb_bootstub qemu qemu-debug
+qemu-record: src/kernel/kernel.elf
+	touch disk.qcow2
+	export RR=record && \
+	qemu-system-riscv64 \
+		-nographic \
+		-kernel src/kernel/kernel.elf \
+		$(target-timetravel-qemuflags) \
+		$(QEMUFLAGS)
+
+qemu-replay: src/kernel/kernel.elf
+	touch disk.qcow2
+	export RR=replay && \
+	qemu-system-riscv64 \
+		-nographic \
+		-kernel src/kernel/kernel.elf \
+		-s -S \
+		$(target-timetravel-qemuflags) \
+		$(QEMUFLAGS)
+
+.PHONY: gdb gdb_bootstub qemu qemu-debug qemu-record qemu-replay
 
 # A target for dumping the kernel.
 objdump: src/kernel/arch/riscv64/kernel-unstripped.elf

--- a/src/targets/riscv64/qemu-riscv64.mak
+++ b/src/targets/riscv64/qemu-riscv64.mak
@@ -4,3 +4,9 @@
 
 kernel-cflags += -march=rv64imafdcbv_zicsr_zicntr_zihpm_ziccif_ziccrse_ziccamoa_zicclsm_zic64b_za64rs_zihintpause_zba_zbb_zbs_zicbom_zicbop_zicboz_zfhmin_zkt_zvfhmin_zvbb_zvkt_zihintntl_zicond_zimop_zcmop_zcb_zfa_zawrs_svpbmt_svinval_svnapot_sstc_sscofpmf_zifencei
 target-qemuflags = --machine virt --cpu rva23s64 --smp 2 -m 1G --netdev user,id=net0 -device rtl8139,netdev=net0,bus=pcie.0
+target-timetravel-qemuflags = -icount shift=auto,rr=$$RR,rrfile=replay.bin \
+               -drive file=disk.qcow2,if=none,snapshot=on,id=img-direct \
+               -drive driver=blkreplay,if=none,image=img-direct,id=img-blkreplay \
+               -netdev user,id=net0 -device rtl8139,netdev=net0 \
+               -object filter-replay,id=replay,netdev=net0 \
+               --machine virt --cpu rva23s64 --smp 1 -m 1G


### PR DESCRIPTION
This adds time travel debugging using qemu's built in replay/record.
Only qemu-riscv64 is added. It is the highest priority target and meant
as the default virtual environment.

`make qemu-record`: Record a debug playback.
`make qemu-replay`: Replay a debug playback for gdb. Run `make gdb` in
another terminal.

`rsi` or `reverse-stepi` steps one instruction backwards and `rc` or
`reverse-continue` finds the most recent breakpoint in the past.

This adds a time travel debugging tutorial to the docs. It says only
`qemu-riscv64` is supported, because the other targets aren't added at
this point.

This should close #42 .

## Merge this after #103 .